### PR TITLE
プロフィールサイトをmonoテーマで全面再デザイン

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "static",
+      "runtimeExecutable": "python3",
+      "runtimeArgs": ["-m", "http.server", "5173"],
+      "port": 5173
+    }
+  ]
+}

--- a/css/main-mono.css
+++ b/css/main-mono.css
@@ -1002,4 +1002,29 @@ img {
     gap: 6px;
     padding: 20px 18px 28px;
   }
+
+  .pub-filter {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+  }
+
+  .pub-filter__tabs {
+    width: 100%;
+  }
+
+  .pub-filter__tab {
+    flex: 1;
+    padding: 8px 4px;
+    font-size: 11px;
+    letter-spacing: 0.8px;
+    text-align: center;
+  }
+
+  .pub-filter__tab small {
+    display: block;
+    margin-left: 0;
+    margin-top: 2px;
+    font-size: 10px;
+  }
 }

--- a/css/main-mono.css
+++ b/css/main-mono.css
@@ -1,0 +1,1002 @@
+/* =============================================================================
+   The Funayama Notebook — Profile Redesign
+   Edition: mono · Accent: default · Density: compact · Hero size: modest
+   ============================================================================= */
+
+:root {
+  --bg: #FFFFFF;
+  --panel: #F5F5F2;
+  --ink: #0A0A0A;
+  --muted: #5A5A5A;
+  --rule: #0A0A0A;
+  --rule-soft: rgba(10, 10, 10, 0.14);
+  --accent: #0A0A0A;
+  --tag-bg: rgba(10, 10, 10, 0.05);
+
+  --serif: 'EB Garamond', 'Noto Serif JP', Georgia, serif;
+  --jp: 'Noto Serif JP', serif;
+  --mono: 'JetBrains Mono', ui-monospace, monospace;
+
+  /* compact density */
+  --pad-sec-y: 32px;
+  --pad-sec-x: 64px;
+
+  /* modest hero */
+  --hero-fs: 56px;
+
+  --max-w: 1200px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--serif);
+  font-feature-settings: 'liga', 'dlig', 'onum';
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+::selection {
+  background: var(--ink);
+  color: var(--bg);
+}
+
+a {
+  color: inherit;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+/* =========================== TOP NAV =================================== */
+
+.top-nav {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: rgba(255, 255, 255, 0.92);
+  border-bottom: 1px solid var(--rule);
+  padding: 16px var(--pad-sec-x);
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+
+.top-nav__brand {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  text-decoration: none;
+  color: var(--ink);
+}
+
+.top-nav__brand-en {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 26px;
+  font-weight: 500;
+}
+
+.top-nav__brand-ja {
+  font-family: var(--jp);
+  font-size: 15px;
+  color: var(--muted);
+}
+
+.top-nav__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 26px;
+}
+
+.top-nav__link {
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+  color: var(--ink);
+  text-decoration: none;
+  padding: 4px 0;
+  border-bottom: 1px solid transparent;
+  transition: border-color 120ms ease;
+}
+
+.top-nav__link:hover {
+  border-bottom-color: var(--ink);
+}
+
+.top-nav__menu-toggle {
+  display: none;
+  background: none;
+  border: 1px solid var(--rule);
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  cursor: pointer;
+  position: relative;
+}
+
+.top-nav__menu-toggle span {
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  height: 1px;
+  background: var(--ink);
+}
+
+.top-nav__menu-toggle span:nth-child(1) { top: 12px; }
+.top-nav__menu-toggle span:nth-child(2) { top: 17px; }
+.top-nav__menu-toggle span:nth-child(3) { top: 22px; }
+
+/* =========================== SECTIONS =================================== */
+
+.section {
+  padding: var(--pad-sec-y) var(--pad-sec-x);
+  border-bottom: 1px solid var(--rule-soft);
+  max-width: var(--max-w);
+  margin: 0 auto;
+  scroll-margin-top: 72px;
+}
+
+#experience,
+#education,
+#awards,
+.hero {
+  scroll-margin-top: 72px;
+}
+
+.section--panel {
+  background: var(--panel);
+  max-width: none;
+  margin: 0;
+  padding-left: calc((100vw - var(--max-w)) / 2 + var(--pad-sec-x));
+  padding-right: calc((100vw - var(--max-w)) / 2 + var(--pad-sec-x));
+}
+
+@media (max-width: 1328px) {
+  .section--panel {
+    padding-left: var(--pad-sec-x);
+    padding-right: var(--pad-sec-x);
+  }
+}
+
+.section-title {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  margin: 0 0 20px;
+}
+
+.section-title__en {
+  margin: 0;
+  font-family: var(--serif);
+  font-size: 36px;
+  font-weight: 500;
+  letter-spacing: -0.5px;
+}
+
+.section-title__ja {
+  font-family: var(--jp);
+  color: var(--muted);
+  font-size: 19px;
+}
+
+.section-title__rule {
+  flex: 1;
+  height: 1px;
+  background: var(--rule-soft);
+  margin-left: 6px;
+}
+
+.section-sub-title {
+  font-family: var(--serif);
+  font-size: 18px;
+  font-weight: 500;
+  font-style: italic;
+  color: var(--ink);
+  margin: 28px 0 14px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--rule-soft);
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.section-sub-title__ja {
+  font-family: var(--jp);
+  font-size: 14px;
+  font-style: normal;
+  color: var(--muted);
+  font-weight: 400;
+}
+
+.section-sub-title__count {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 1px;
+  color: var(--muted);
+  font-style: normal;
+  font-weight: 400;
+}
+
+/* =========================== HERO ======================================= */
+
+.hero {
+  padding: 48px var(--pad-sec-x) 40px;
+  border-bottom: 1px solid var(--rule-soft);
+  max-width: var(--max-w);
+  margin: 0 auto;
+}
+
+.hero__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: 56px;
+  align-items: start;
+}
+
+.hero__eyebrow {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 1.6px;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 16px;
+}
+
+.hero__title {
+  margin: 0;
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: var(--hero-fs);
+  line-height: 1;
+  letter-spacing: -2px;
+}
+
+.hero__subtitle {
+  font-family: var(--jp);
+  font-size: 24px;
+  color: var(--muted);
+  margin-top: 10px;
+  letter-spacing: 2px;
+}
+
+.hero__lede {
+  margin: 26px 0 0;
+  font-family: var(--serif);
+  font-size: 24px;
+  line-height: 1.55;
+  max-width: 680px;
+}
+
+.hero__lede em {
+  font-style: italic;
+}
+
+.hero__lede-ja {
+  margin: 14px 0 0;
+  font-family: var(--jp);
+  font-size: 17px;
+  line-height: 1.75;
+  color: var(--muted);
+  max-width: 680px;
+}
+
+.hero__meta {
+  margin: 32px 0 0;
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  row-gap: 14px;
+  column-gap: 20px;
+  font-size: 17px;
+}
+
+.hero__meta dt {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+  color: var(--muted);
+  padding-top: 6px;
+  border-top: 1px solid var(--rule-soft);
+}
+
+.hero__meta dt small {
+  display: block;
+  font-family: var(--jp);
+  font-size: 10px;
+  margin-top: 2px;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.hero__meta dd {
+  margin: 0;
+  padding-top: 6px;
+  border-top: 1px solid var(--rule-soft);
+  font-family: var(--serif);
+}
+
+.hero__meta dd a {
+  color: var(--ink);
+  text-decoration: none;
+  border-bottom: 1px solid var(--rule-soft);
+  transition: border-color 120ms ease;
+}
+
+.hero__meta dd a:hover {
+  border-bottom-color: var(--ink);
+}
+
+.affil-list,
+.contact-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.affil-list li {
+  margin-bottom: 4px;
+}
+
+.affil-list li small {
+  font-family: var(--jp);
+  color: var(--muted);
+  font-size: 15px;
+  margin-left: 4px;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.tag-list li {
+  padding: 4px 10px;
+  border: 1px solid var(--rule-soft);
+  background: var(--tag-bg);
+  font-family: var(--serif);
+  font-size: 16px;
+  border-radius: 2px;
+}
+
+.tag-list li small {
+  font-family: var(--jp);
+  color: var(--muted);
+  margin-left: 6px;
+  font-size: 14px;
+}
+
+.contact-list {
+  font-family: var(--mono);
+  font-size: 15px;
+  line-height: 1.85;
+}
+
+.contact-list li span {
+  color: var(--muted);
+  margin-right: 10px;
+  display: inline-block;
+  min-width: 70px;
+}
+
+.hero__portrait {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 5;
+  background: #D9CFB8;
+  border: 1px solid var(--rule);
+  overflow: hidden;
+}
+
+.hero__portrait img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.hero__caption {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 14px;
+  color: var(--muted);
+  margin-top: 10px;
+  line-height: 1.5;
+}
+
+.hero__caption a {
+  color: var(--muted);
+}
+
+/* =========================== NEWS / RECENT ============================== */
+
+.news-list {
+  list-style: none;
+  margin: 16px 0 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px 40px;
+}
+
+.news-list li {
+  display: grid;
+  grid-template-columns: 76px 1fr;
+  gap: 14px;
+  align-items: baseline;
+}
+
+.news-list__date {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--accent);
+  letter-spacing: 1px;
+  font-weight: 500;
+}
+
+.news-list__text {
+  font-family: var(--serif);
+  font-size: 17px;
+  line-height: 1.55;
+}
+
+/* =========================== PUB FILTER ================================= */
+
+.pub-filter {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 4px 0 18px;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.pub-filter__tabs {
+  display: flex;
+  border: 1px solid var(--rule);
+}
+
+.pub-filter__tab {
+  padding: 8px 16px;
+  border: none;
+  border-right: 1px solid var(--rule);
+  background: transparent;
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.pub-filter__tab:last-child {
+  border-right: none;
+}
+
+.pub-filter__tab small {
+  font-family: var(--jp);
+  opacity: 0.7;
+  margin-left: 6px;
+  font-size: 11px;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.pub-filter__tab:hover {
+  background: var(--tag-bg);
+}
+
+.pub-filter__tab.is-active {
+  background: var(--ink);
+  color: var(--bg);
+}
+
+.pub-filter__tab.is-active small {
+  opacity: 0.85;
+}
+
+.pub-filter__count {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--muted);
+  letter-spacing: 1px;
+}
+
+/* =========================== PUBLICATIONS =============================== */
+
+.pub-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--rule);
+  counter-reset: pub;
+}
+
+.pub-list > li {
+  display: grid;
+  grid-template-columns: 50px 1fr 220px;
+  gap: 22px;
+  padding: 16px 0;
+  border-bottom: 1px solid var(--rule-soft);
+  align-items: baseline;
+}
+
+.pub-list__year {
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--accent);
+  letter-spacing: 1px;
+  font-weight: 500;
+  padding-top: 4px;
+}
+
+.pub-list__title-ja {
+  font-family: var(--jp);
+  font-size: 19px;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: 4px;
+}
+
+.pub-list__title-en {
+  font-family: var(--serif);
+  font-size: 21px;
+  line-height: 1.4;
+  font-weight: 500;
+}
+
+.pub-list__title-en--with-ja {
+  font-style: italic;
+  color: var(--muted);
+  font-size: 17px;
+}
+
+.pub-list__authors {
+  font-family: var(--serif);
+  font-size: 15px;
+  color: var(--muted);
+  margin-top: 6px;
+  line-height: 1.6;
+}
+
+.pub-list__authors u,
+.pub-list__authors .me {
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  color: var(--ink);
+}
+
+.pub-list__venue {
+  font-family: var(--serif);
+  font-size: 15px;
+  font-style: italic;
+  margin-top: 4px;
+  color: var(--ink);
+}
+
+.pub-list__venue .details {
+  color: var(--muted);
+  font-style: normal;
+}
+
+.pub-list__links {
+  display: flex;
+  gap: 14px;
+  align-items: baseline;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.pub-list__link {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 1.2px;
+  color: var(--accent);
+  text-decoration: none;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 1px;
+}
+
+.pub-list__link--quiet {
+  color: var(--muted);
+  border-bottom-color: transparent;
+}
+
+.pub-list__badge {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  padding: 2px 8px;
+  margin-top: 6px;
+  margin-right: 6px;
+}
+
+/* =========================== TALKS ====================================== */
+
+.talks-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--rule);
+}
+
+.talks-list > li {
+  display: grid;
+  grid-template-columns: 110px 1fr 200px;
+  gap: 22px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--rule-soft);
+  align-items: baseline;
+}
+
+.talks-list__date {
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--accent);
+  letter-spacing: 1px;
+  font-weight: 500;
+}
+
+.talks-list__title {
+  font-family: var(--jp);
+  font-size: 19px;
+  line-height: 1.45;
+  font-weight: 500;
+}
+
+.talks-list__title--en {
+  font-family: var(--serif);
+}
+
+.talks-list__venue {
+  font-family: var(--serif);
+  font-size: 15px;
+  font-style: italic;
+  color: var(--muted);
+  margin-top: 4px;
+}
+
+.talks-list__meta {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  align-items: baseline;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.talks-list__meta a {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--accent);
+}
+
+/* =========================== EXPERIENCE / EDUCATION ===================== */
+
+.exp-edu {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 56px;
+}
+
+.timeline {
+  list-style: none;
+  margin: 16px 0 0;
+  padding: 0;
+  border-top: 1px solid var(--rule);
+}
+
+.timeline > li {
+  display: grid;
+  grid-template-columns: 130px 1fr;
+  gap: 16px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--rule-soft);
+  align-items: baseline;
+}
+
+.timeline__date {
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--accent);
+  letter-spacing: 1px;
+}
+
+.timeline__primary {
+  font-family: var(--serif);
+  font-size: 18px;
+  line-height: 1.4;
+  font-weight: 500;
+}
+
+.timeline__secondary {
+  font-family: var(--serif);
+  font-size: 15px;
+  font-style: italic;
+  color: var(--muted);
+  margin-top: 2px;
+}
+
+/* =========================== AWARDS ===================================== */
+
+.awards-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--rule);
+}
+
+.awards-list > li {
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  gap: 18px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--rule-soft);
+  align-items: baseline;
+}
+
+.awards-list__year {
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--accent);
+  letter-spacing: 1px;
+  font-weight: 500;
+}
+
+.awards-list__title {
+  font-family: var(--jp);
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.awards-list__title--en {
+  font-family: var(--serif);
+}
+
+.awards-list__title a {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid var(--rule-soft);
+}
+
+.awards-list__title a:hover {
+  border-bottom-color: var(--ink);
+}
+
+.awards-list__body {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 15px;
+  color: var(--muted);
+  margin-top: 2px;
+}
+
+/* =========================== FOOTER ===================================== */
+
+.footer-mini {
+  padding: 28px var(--pad-sec-x) 36px;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  max-width: var(--max-w);
+  margin: 0 auto;
+}
+
+.footer-mini__copy {
+  font-family: var(--serif);
+  font-size: 16px;
+  color: var(--muted);
+}
+
+.footer-mini__updated {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 1.2px;
+  color: var(--muted);
+}
+
+/* =========================== RESPONSIVE ================================= */
+
+@media (max-width: 960px) {
+  :root {
+    --pad-sec-x: 32px;
+    --hero-fs: 44px;
+  }
+
+  .hero__grid {
+    grid-template-columns: 1fr;
+    gap: 28px;
+  }
+
+  .hero__portrait-wrap {
+    order: -1;
+    max-width: 240px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .news-list {
+    grid-template-columns: 1fr;
+  }
+
+  .pub-list > li {
+    grid-template-columns: 56px 1fr;
+  }
+
+  .pub-list__links {
+    grid-column: 2;
+    justify-content: flex-start;
+    margin-top: 6px;
+  }
+
+  .talks-list > li {
+    grid-template-columns: 90px 1fr;
+  }
+
+  .talks-list__meta {
+    grid-column: 2;
+    justify-content: flex-start;
+    margin-top: 4px;
+  }
+
+  .exp-edu {
+    grid-template-columns: 1fr;
+    gap: 32px;
+  }
+}
+
+@media (max-width: 640px) {
+  :root {
+    --pad-sec-x: 18px;
+    --pad-sec-y: 24px;
+    --hero-fs: 36px;
+  }
+
+  .top-nav {
+    padding: 12px 18px;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+  }
+
+  .top-nav nav {
+    order: 3;
+    flex-basis: 100%;
+  }
+
+  .top-nav__list {
+    display: none;
+    flex-direction: column;
+    gap: 0;
+    border-top: 1px solid var(--rule-soft);
+    padding-top: 8px;
+    margin-top: 8px;
+  }
+
+  .top-nav__list.is-open {
+    display: flex;
+  }
+
+  .top-nav__list li {
+    padding: 8px 0;
+    border-bottom: 1px solid var(--rule-soft);
+  }
+
+  .top-nav__menu-toggle {
+    display: block;
+    order: 2;
+  }
+
+  .top-nav__brand {
+    order: 1;
+  }
+
+  .top-nav__brand-en {
+    font-size: 18px;
+  }
+
+  .hero {
+    padding: 28px 18px 24px;
+  }
+
+  .hero__title {
+    line-height: 1.05;
+  }
+
+  .hero__subtitle {
+    font-size: 18px;
+  }
+
+  .hero__lede {
+    font-size: 17px;
+  }
+
+  .hero__meta {
+    grid-template-columns: 1fr;
+    row-gap: 14px;
+  }
+
+  .hero__meta dt {
+    padding-top: 10px;
+  }
+
+  .hero__meta dd {
+    padding-top: 4px;
+    border-top: none;
+  }
+
+  .news-list li {
+    grid-template-columns: 60px 1fr;
+    gap: 10px;
+  }
+
+  .pub-list > li {
+    grid-template-columns: 50px 1fr;
+    gap: 12px;
+  }
+
+  .pub-list__title-en {
+    font-size: 16px;
+  }
+
+  .pub-list__title-ja {
+    font-size: 15px;
+  }
+
+  .talks-list > li {
+    grid-template-columns: 78px 1fr;
+    gap: 12px;
+  }
+
+  .talks-list__title {
+    font-size: 15px;
+  }
+
+  .timeline > li {
+    grid-template-columns: 110px 1fr;
+    gap: 12px;
+  }
+
+  .awards-list > li {
+    grid-template-columns: 76px 1fr;
+    gap: 12px;
+  }
+
+  .footer-mini {
+    flex-direction: column;
+    gap: 6px;
+    padding: 20px 18px 28px;
+  }
+}

--- a/css/main-mono.css
+++ b/css/main-mono.css
@@ -399,9 +399,9 @@ img {
 
 .contact-list li span {
   color: var(--muted);
-  margin-right: 10px;
+  margin-right: 14px;
   display: inline-block;
-  min-width: 70px;
+  min-width: 110px;
 }
 
 .hero__portrait {

--- a/css/main-mono.css
+++ b/css/main-mono.css
@@ -888,7 +888,7 @@ img {
   }
 
   .top-nav {
-    padding: 12px 18px;
+    padding: 14px 18px;
     flex-wrap: wrap;
     gap: 8px;
     align-items: center;
@@ -898,6 +898,19 @@ img {
     order: 3;
     flex-basis: 100%;
   }
+
+  .top-nav__brand {
+    align-items: center;
+  }
+
+  .top-nav__menu-toggle {
+    width: 32px;
+    height: 32px;
+  }
+
+  .top-nav__menu-toggle span:nth-child(1) { top: 10px; }
+  .top-nav__menu-toggle span:nth-child(2) { top: 15px; }
+  .top-nav__menu-toggle span:nth-child(3) { top: 20px; }
 
   .top-nav__list {
     display: none;

--- a/css/main-mono.css
+++ b/css/main-mono.css
@@ -591,7 +591,7 @@ img {
 
 .pub-list__venue {
   font-family: var(--serif);
-  font-size: 14px;
+  font-size: 16px;
   font-style: italic;
   margin-top: 4px;
   color: var(--ink);

--- a/css/main-mono.css
+++ b/css/main-mono.css
@@ -554,7 +554,7 @@ img {
 
 .pub-list__title-ja {
   font-family: var(--jp);
-  font-size: 19px;
+  font-size: 18px;
   font-weight: 500;
   line-height: 1.5;
   margin-bottom: 4px;
@@ -562,7 +562,7 @@ img {
 
 .pub-list__title-en {
   font-family: var(--serif);
-  font-size: 21px;
+  font-size: 19px;
   line-height: 1.4;
   font-weight: 500;
 }
@@ -570,12 +570,12 @@ img {
 .pub-list__title-en--with-ja {
   font-style: italic;
   color: var(--muted);
-  font-size: 17px;
+  font-size: 16px;
 }
 
 .pub-list__authors {
   font-family: var(--serif);
-  font-size: 15px;
+  font-size: 16px;
   color: var(--muted);
   margin-top: 6px;
   line-height: 1.6;
@@ -591,7 +591,7 @@ img {
 
 .pub-list__venue {
   font-family: var(--serif);
-  font-size: 15px;
+  font-size: 14px;
   font-style: italic;
   margin-top: 4px;
   color: var(--ink);

--- a/css/main-mono.css
+++ b/css/main-mono.css
@@ -310,19 +310,22 @@ img {
 
 .hero__meta dt {
   font-family: var(--mono);
-  font-size: 10px;
+  font-size: 13px;
+  font-weight: 500;
   letter-spacing: 1.4px;
   text-transform: uppercase;
-  color: var(--muted);
-  padding-top: 6px;
+  color: var(--ink);
+  padding-top: 8px;
   border-top: 1px solid var(--rule-soft);
 }
 
 .hero__meta dt small {
   display: block;
   font-family: var(--jp);
-  font-size: 10px;
-  margin-top: 2px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--muted);
+  margin-top: 3px;
   letter-spacing: 0;
   text-transform: none;
 }

--- a/index.html
+++ b/index.html
@@ -51,18 +51,19 @@
 <section class="hero" id="about">
   <div class="hero__grid">
     <div class="hero__main">
-      <div class="hero__eyebrow">Researcher · NLP × Education</div>
+      <div class="hero__eyebrow">Researcher &amp; Engineer · NLP × Education</div>
       <h1 class="hero__title">Hiroaki Funayama</h1>
       <div class="hero__subtitle">舟山 弘晃</div>
 
       <p class="hero__lede">
-        I work on natural language processing for education —
-        building models that <em>score short-answer questions</em>
-        and generate feedback to support student learning.
+        I am a researcher and engineer in natural language processing,
+        with a focus on education. My goal is to <em>build AI that supports every learner</em>
+        — particularly through automated scoring and feedback generation for written responses.
       </p>
       <p class="hero__lede-ja">
-        自然言語処理の教育応用を研究しています。
-        短答式記述問題の自動採点と、学習者を支えるフィードバック生成が主なテーマです。
+        自然言語処理を専門とする研究者・エンジニアで、特に教育への応用に取り組んでいます。
+        一人ひとりの学びを支える AI をつくることを目指し、
+        記述式答案の自動採点とフィードバック生成を中心に研究・開発しています。
       </p>
 
       <dl class="hero__meta">

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
 
         <dt>Interests<small>専門</small></dt>
         <dd>
-          <ul class="tag-list">
+          <ul class="affil-list">
             <li>Natural Language Processing <small>自然言語処理</small></li>
             <li>AI for Education <small>教育AI</small></li>
             <li>Learning Support Systems <small>学習支援システム</small></li>

--- a/index.html
+++ b/index.html
@@ -58,12 +58,12 @@
       <p class="hero__lede">
         I am a researcher and engineer in natural language processing,
         with a focus on education. My goal is to <em>build AI that supports every learner, wherever they are</em>
-        — particularly through automated scoring and feedback generation for written responses.
+        — opening up new ways to learn through language technology.
       </p>
       <p class="hero__lede-ja">
         自然言語処理を専門とする研究者・エンジニアで、特に教育への応用に取り組んでいます。
-        どこにいる学習者にも届く AI をつくることを目指し、
-        記述式答案の自動採点とフィードバック生成を中心に研究・開発しています。
+        どこにいる学習者にも届く AI をつくり、
+        言語技術によって学びのかたちを多様にしていくことを目指しています。
       </p>
 
       <dl class="hero__meta">

--- a/index.html
+++ b/index.html
@@ -56,12 +56,13 @@
       <div class="hero__subtitle">舟山 弘晃</div>
 
       <p class="hero__lede">
-        I build language models that <em>read student writing the way a kind teacher would</em>
-        — scoring short answers, diagnosing them, and helping learners through useful feedback.
+        I work on natural language processing for education —
+        building models that <em>score short-answer questions</em>
+        and generate feedback to support student learning.
       </p>
       <p class="hero__lede-ja">
-        短答式答案の自動採点と、学びを支えるフィードバック生成を研究しています。
-        現在は MLS Inc. の AI アーキテクト、東北大学および理研 AIP の研究員。
+        自然言語処理の教育応用を研究しています。
+        短答式記述問題の自動採点と、学習者を支えるフィードバック生成が主なテーマです。
       </p>
 
       <dl class="hero__meta">

--- a/index.html
+++ b/index.html
@@ -55,15 +55,6 @@
       <h1 class="hero__title">Hiroaki Funayama</h1>
       <div class="hero__subtitle">舟山 弘晃</div>
 
-      <p class="hero__lede">
-        I am a researcher and engineer in natural language processing,
-        with a focus on education. My goal is to <em>build AI that stays close to every learner</em>
-        — making education more open and more personal.
-      </p>
-      <p class="hero__lede-ja">
-        自然言語処理 × 教育を専門に、研究と社会実装の両軸で取り組んでいます。
-      </p>
-
       <dl class="hero__meta">
         <dt>Affiliation<small>所属</small></dt>
         <dd>

--- a/index.html
+++ b/index.html
@@ -57,13 +57,11 @@
 
       <p class="hero__lede">
         I am a researcher and engineer in natural language processing,
-        with a focus on education. My goal is to <em>build AI that supports every learner, wherever they are</em>
-        — opening up new ways to learn through language technology.
+        with a focus on education. My goal is to <em>build AI that stays close to every learner</em>
+        — making education more open and more personal.
       </p>
       <p class="hero__lede-ja">
-        自然言語処理を専門とする研究者・エンジニアで、特に教育への応用に取り組んでいます。
-        どこにいる学習者にも届く AI をつくり、
-        言語技術によって学びのかたちを多様にしていくことを目指しています。
+        自然言語処理 × 教育を専門に、研究と社会実装の両軸で取り組んでいます。
       </p>
 
       <dl class="hero__meta">

--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
         <dd>
           <ul class="contact-list">
             <li><span>MLS</span>funayama at machine-learning.co.jp</li>
-            <li><span>Tohoku</span>h.funayama at tohoku.ac.jp</li>
+            <li><span>Tohoku Univ.</span>h.funayama at tohoku.ac.jp</li>
             <li><span>RIKEN</span>hiroaki.funayama at riken.jp</li>
           </ul>
         </dd>

--- a/index.html
+++ b/index.html
@@ -57,12 +57,12 @@
 
       <p class="hero__lede">
         I am a researcher and engineer in natural language processing,
-        with a focus on education. My goal is to <em>build AI that supports every learner</em>
+        with a focus on education. My goal is to <em>build AI that supports every learner, wherever they are</em>
         — particularly through automated scoring and feedback generation for written responses.
       </p>
       <p class="hero__lede-ja">
         自然言語処理を専門とする研究者・エンジニアで、特に教育への応用に取り組んでいます。
-        一人ひとりの学びを支える AI をつくることを目指し、
+        どこにいる学習者にも届く AI をつくることを目指し、
         記述式答案の自動採点とフィードバック生成を中心に研究・開発しています。
       </p>
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="" lang="en">
+<html lang="en">
 
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-Q5YC66F31D"></script>
@@ -7,564 +7,725 @@
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-
     gtag('config', 'G-Q5YC66F31D');
 </script>
 
 <head>
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <title>Hiroaki Funayama</title>
-  <meta name="description" content="">
+  <title>Hiroaki Funayama — 舟山 弘晃</title>
+  <meta name="description" content="Hiroaki Funayama — researcher in NLP for education. Short-answer scoring, learning support systems, and large language models.">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <!-- inject:css -->
-  <!-- endinject -->
-  <link href="https://fonts.googleapis.com/css?family=Lato:400,700,900|Lora:400,400i,700" rel="stylesheet">
-  
-<link rel="stylesheet" href="css/main-blue.css" data-pin="img/icofont-location-pin--blue.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Noto+Serif+JP:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
-
-  <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
-  <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
-  <!--[if lt IE 9]>
-  <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
-  <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
-  <![endif]-->
-  <!-- Yandex.Metrika counter -->
-<!--   <script type="text/javascript">
-      (function (d, w, c) {
-          (w[c] = w[c] || []).push(function() {
-              try {
-                  w.yaCounter42961429 = new Ya.Metrika({
-                      id:42961429,
-                      clickmap:true,
-                      trackLinks:true,
-                      accurateTrackBounce:true,
-                      webvisor:true,
-                      trackHash:true
-                  });
-              } catch(e) { }
-          });
-
-          var n = d.getElementsByTagName("script")[0],
-              s = d.createElement("script"),
-              f = function () { n.parentNode.insertBefore(s, n); };
-          s.type = "text/javascript";
-          s.async = true;
-          s.src = "https://mc.yandex.ru/metrika/watch.js";
-
-          if (w.opera == "[object Opera]") {
-              d.addEventListener("DOMContentLoaded", f, false);
-          } else { f(); }
-      })(document, window, "yandex_metrika_callbacks");
-  </script>
-  <noscript><div><img src="https://mc.yandex.ru/watch/42961429" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
-  <!-- /Yandex.Metrika counter --> 
+  <link rel="stylesheet" href="css/main-mono.css">
 </head>
+
 <body>
-    <!--[if lt IE 10]>
-        <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
-    <![endif]-->
 
-    <div class="ie-overflow-fix" style="overflow:hidden;">
-      
-
-
-<link rel="stylesheet" href="css/main-blue.css" data-pin="img/icofont-location-pin--blue.png">
-
-
-
-
-
-<header class="c-main-header">
-
-  <div class="o-container">
-
-    <!-- NAVIGATION -->
-    <div class="c-main-header__nav-wrapper" data-menuAnimated="true">
-      <nav class="c-main-nav js-main-nav">
-        <ul id="site-navigation" class="c-main-nav__list nav-fixed--is-active js-main-nav__list">
-          <li class="c-main-nav__item"><a href="#section-about" class="c-main-nav__link" data-navPosition="1"><span>About</span></a></li>
-          <li class="c-main-nav__item"><a href="#section-publications" class="c-main-nav__link" data-navPosition="2"><span>Publications</span></a></li>
-          <li class="c-main-nav__item"><a href="#section-talks" class="c-main-nav__link" data-navPosition="3"><span>Talks</span></a></li>
-          <li class="c-main-nav__item"><a href="#section-activities" class="c-main-nav__link" data-navPosition="4"><span>Experience</span></a></li>
-          <li class="c-main-nav__item"><a href="#section-education" class="c-main-nav__link" data-navPosition="5"><span>Education</span></a></li>
-          <li class="c-main-nav__item"><a href="#section-award" class="c-main-nav__link" data-navPosition="6"><span>Awards</span></a></li>
-        </ul>
-        <button type="button" class="c-main-nav__bars js-main-nav-toggle" aria-controls="site-navigation" aria-label="ナビゲーションを開閉">
-          <span></span>
-          <span></span>
-          <span></span>
-        </button>
-      </nav>
-    </div>
-    <!-- NAVIGATION END -->
-
-    <!-- ABOUT SECTION-->
-    <div id="section-about" class="c-screen-about o-screen-about" data-contentPosition="1">
-       <div class="o-screen-about__col">
-
-        <figure class="c-screen-about__image">
-          <span></span>
-          <img src="pic/self3.jpg" alt="">
-          <figcaption style="text-align: right; font-style: italic;">Okinawa, 2023 - photo by <a href="https://gokamoda.github.io/">Go Kamoda</a>.</figcaption>
-        </figure>
-      </div>
-      <div class="o-screen-about__col">
-        <h1 class="u-mb-5">Hiroaki Funayama <br>舟山 弘晃</h1>
-<!--        <ul class="c-socials u-mb-35">-->
-<!--                  <li class="c-socials__item">-->
-<!--            <a href="mailto:h.funa&#64;dc.tohoku.ac.jp" class="c-socials__link">-->
-<!--              <i class="icofont icofont-email"></i>-->
-<!--            </a>-->
-<!--          </li>-->
-<!--          <li class="c-socials__item">-->
-<!--            <a href="https://github.com/hiro819" class="c-socials__link">-->
-<!--              <i class="icofont icofont-social-github"></i>-->
-<!--            </a>-->
-<!--          </li>-->
-
-        </ul>
-        <p class="u-mb-10">
-            <br>
-          <h3 class="u-mb-10">Affiliation (所属)</h3>
-        <ul class="c-profile-list c-profile-list--links">
-          <li><a href="https://machine-learning.co.jp/ "> Machine Learning Solutions (MLS) Inc. </a> </li>
-          <li> <a href="https://www.nlp.ecei.tohoku.ac.jp/"> Tohoku NLP Group (東北大学 自然言語処理研究グループ)</a> </li>
-          <li> <a href="https://www.riken.jp/research/labs/aip/goalorient_tech/nat_lang_understand/index.html"> RIKEN AIP （理研AIP 自然言語理解チーム）</a> </li>
-
-        </ul> 
-
-        <br>
-        <h3 class="u-mb-10">Interests (専門)</h3>
-        <ul class="c-profile-list">
-        <li> Natural Language Processing (NLP)</li>
-        <li> AI for Education （教育AI）</li>
-        <li> Learning support system （学習支援システム）</li>
-        <li> Large Language Model (LLM)</li>
-        </ul>
-          <br>
-          <h3 class="u-mb-10">Contact (連絡先)</h3>
-          <ul class="c-profile-list">
-              <li>funayama at machine-learning.co.jp</li>
-              <li>h.funayama at tohoku.ac.jp</li>
-              <li>hiroaki.funayama at riken.jp</li>
-
-          </ul>
-
-
-      </div>
-    </div>
-
-  </div>
-
+<!-- ============================ TOP NAV ============================ -->
+<header class="top-nav">
+  <a href="#about" class="top-nav__brand">
+    <span class="top-nav__brand-en">Hiroaki Funayama</span>
+    <span class="top-nav__brand-ja">舟山 弘晃</span>
+  </a>
+  <nav>
+    <ul class="top-nav__list" id="site-nav">
+      <li><a class="top-nav__link" href="#about">About</a></li>
+      <li><a class="top-nav__link" href="#publications">Publications</a></li>
+      <li><a class="top-nav__link" href="#talks">Talks</a></li>
+      <li><a class="top-nav__link" href="#experience">Experience</a></li>
+      <li><a class="top-nav__link" href="#education">Education</a></li>
+      <li><a class="top-nav__link" href="#awards">Awards</a></li>
+    </ul>
+  </nav>
+  <button class="top-nav__menu-toggle" type="button" aria-controls="site-nav" aria-label="Toggle navigation">
+    <span></span><span></span><span></span>
+  </button>
 </header>
 
+<!-- ============================ HERO ============================ -->
+<section class="hero" id="about">
+  <div class="hero__grid">
+    <div class="hero__main">
+      <div class="hero__eyebrow">Researcher · NLP × Education</div>
+      <h1 class="hero__title">Hiroaki Funayama</h1>
+      <div class="hero__subtitle">舟山 弘晃</div>
 
+      <p class="hero__lede">
+        I build language models that <em>read student writing the way a kind teacher would</em>
+        — scoring short answers, diagnosing them, and helping learners through useful feedback.
+      </p>
+      <p class="hero__lede-ja">
+        短答式答案の自動採点と、学びを支えるフィードバック生成を研究しています。
+        現在は MLS Inc. の AI アーキテクト、東北大学および理研 AIP の研究員。
+      </p>
 
+      <dl class="hero__meta">
+        <dt>Affiliation<small>所属</small></dt>
+        <dd>
+          <ul class="affil-list">
+            <li><a href="https://machine-learning.co.jp/">Machine Learning Solutions (MLS) Inc.</a></li>
+            <li><a href="https://www.nlp.ecei.tohoku.ac.jp/">Tohoku NLP Group</a> <small>東北大学 自然言語処理研究グループ</small></li>
+            <li><a href="https://www.riken.jp/research/labs/aip/goalorient_tech/nat_lang_understand/index.html">RIKEN AIP</a> <small>理研AIP 自然言語理解チーム</small></li>
+          </ul>
+        </dd>
 
+        <dt>Interests<small>専門</small></dt>
+        <dd>
+          <ul class="tag-list">
+            <li>Natural Language Processing <small>自然言語処理</small></li>
+            <li>AI for Education <small>教育AI</small></li>
+            <li>Learning Support Systems <small>学習支援システム</small></li>
+            <li>Large Language Models <small>大規模言語モデル</small></li>
+          </ul>
+        </dd>
 
-<main class="o-main">
-
-
-  <!-- Publication -->
-  <div id="section-publications" class="o-container wow1 fadeIn" data-contentPosition="2">
-
-    <div class="c-section-heading">
-    <!--      <svg class="c-section-heading__icon svg-icon" xmlns="http://www.w3.org/2000/svg" width="91" height="91" viewBox="0 0 91 91">-->
-    <!--        <rect class="svg-icon__border" x="0.5" y="0.5" width="90" height="90"/>-->
-    <!--        <path class="svg-icon__item" d="M436.894,3644.08v41.3h-32.8v-41.3h4.25v-1.05a1.437,1.437,0,0,1,.35-1.02,1.091,1.091,0,0,1,.9-0.35,1.151,1.151,0,0,1,.875.4,1.5,1.5,0,0,1,.325,1.02v1h1.2v-1.05a1.42,1.42,0,0,1,.325-0.97,1.1,1.1,0,0,1,.875-0.38,1.179,1.179,0,0,1,.9.38,1.437,1.437,0,0,1,.35,1.02v0.95h1.2v-1.1a1.209,1.209,0,0,1,.35-0.9,1.231,1.231,0,0,1,.85-0.37,1.092,1.092,0,0,1,.85.3,1.112,1.112,0,0,1,.35.87l0.05,1.2h1.2v-0.55a2.417,2.417,0,0,1,.3-1.37,1.08,1.08,0,0,1,.925-0.45,0.916,0.916,0,0,1,.9.42,2.774,2.774,0,0,1,.275,1.4v0.55h1.25v-1.05a1.635,1.635,0,0,1,.375-0.97,0.994,0.994,0,0,1,.85-0.35,1.126,1.126,0,0,1,.85.4,1.635,1.635,0,0,1,.375.97v1.05h1.2v-1.1a1.28,1.28,0,0,1,.35-0.95,1.207,1.207,0,0,1,1.7,0,1.393,1.393,0,0,1,.4.9v1.15h1.2v-1.15a1.209,1.209,0,0,1,.35-0.9,1.231,1.231,0,0,1,.85-0.37,1.092,1.092,0,0,1,.85.3,1.112,1.112,0,0,1,.35.87v1.25h4.25Zm-26.5,10.75a1.018,1.018,0,0,0-.3.75,0.921,0.921,0,0,0,.325.73,1.327,1.327,0,0,0,.875.27h18.75a0.938,0.938,0,0,0,.85-0.8,1.025,1.025,0,0,0-.2-0.9,1.131,1.131,0,0,0-.9-0.35h-18.6A1.082,1.082,0,0,0,410.394,3654.83Zm0,4.15a1.018,1.018,0,0,0-.3.75,0.921,0.921,0,0,0,.325.73,1.327,1.327,0,0,0,.875.27h18.75a0.96,0.96,0,0,0,.85-0.8,0.983,0.983,0,0,0-.225-0.9,1.148,1.148,0,0,0-.875-0.35h-18.6A1.082,1.082,0,0,0,410.394,3658.98Zm0,12.53a1.057,1.057,0,0,0,.025,1.5,1.327,1.327,0,0,0,.875.27l18.75-.05a0.776,0.776,0,0,0,.575-0.22,1.007,1.007,0,0,0,.275-0.58,0.983,0.983,0,0,0-.225-0.9,1.021,1.021,0,0,0-.875-0.3l-13.85-.05h-4.75A1.291,1.291,0,0,0,410.394,3671.51Zm20.25,5.62a1.018,1.018,0,0,0,.3-0.75,0.888,0.888,0,0,0-.325-0.72,1.359,1.359,0,0,0-.925-0.28h-18.7a0.938,0.938,0,0,0-.85.8,0.89,0.89,0,0,0,.175.9,1.212,1.212,0,0,0,.925.35h18.6A1.082,1.082,0,0,0,430.644,3677.13Zm0-8.32a0.987,0.987,0,0,0,.3-0.75,0.921,0.921,0,0,0-.325-0.75,1.359,1.359,0,0,0-.925-0.28h-18.7a0.972,0.972,0,0,0-.575.28,1.3,1.3,0,0,0-.325.57,1.086,1.086,0,0,0,.25.85,1.131,1.131,0,0,0,.9.35h18.6A1.151,1.151,0,0,0,430.644,3668.81Zm0-4.18a1.048,1.048,0,0,0,.3-0.77,0.868,0.868,0,0,0-.325-0.73,1.47,1.47,0,0,0-.925-0.25h-18.7a1.072,1.072,0,0,0-.575.25,1.132,1.132,0,0,0-.325.55,0.983,0.983,0,0,0,.225.9,1.212,1.212,0,0,0,.925.35h18.6A1.082,1.082,0,0,0,430.644,3664.63Z" transform="translate(-374.5 -3619.5)"/>-->
-    <!--      </svg>-->
-      <h2 class="c-section-heading__header">Publications</h2>
+        <dt>Contact<small>連絡先</small></dt>
+        <dd>
+          <ul class="contact-list">
+            <li><span>MLS</span>funayama at machine-learning.co.jp</li>
+            <li><span>Tohoku</span>h.funayama at tohoku.ac.jp</li>
+            <li><span>RIKEN</span>hiroaki.funayama at riken.jp</li>
+          </ul>
+        </dd>
+      </dl>
     </div>
-      <div class="c-section-sub_heading">
-        <h3 class="c-section-heading__header">International Conference and Journals （Refereed）</h3>
-      </div>
+
+    <div class="hero__portrait-wrap">
+      <figure style="margin: 0;">
+        <div class="hero__portrait">
+          <img src="pic/self3.jpg" alt="Hiroaki Funayama, Okinawa 2023">
+        </div>
+        <figcaption class="hero__caption">
+          Okinawa, 2023 — photo by <a href="https://gokamoda.github.io/">Go Kamoda</a>.
+        </figcaption>
+      </figure>
+    </div>
+  </div>
+</section>
+
+<!-- ============================ PUBLICATIONS ============================ -->
+<section class="section" id="publications">
+  <div class="section-title">
+    <h2 class="section-title__en">Publications</h2>
+    <span class="section-title__ja">業績</span>
+    <span class="section-title__rule"></span>
+  </div>
+
+  <div class="pub-filter">
+    <div class="pub-filter__tabs" role="tablist">
+      <button type="button" class="pub-filter__tab is-active" data-filter="all" role="tab" aria-selected="true">All <small>全て</small></button>
+      <button type="button" class="pub-filter__tab" data-filter="journal" role="tab" aria-selected="false">Journal <small>論文誌</small></button>
+      <button type="button" class="pub-filter__tab" data-filter="international" role="tab" aria-selected="false">International <small>国際会議</small></button>
+      <button type="button" class="pub-filter__tab" data-filter="domestic" role="tab" aria-selected="false">Domestic <small>国内</small></button>
+    </div>
+    <div class="pub-filter__count" id="pub-count">— entries</div>
+  </div>
+
+  <ol class="pub-list" id="pub-list">
+    <li data-type="journal">
+      <span class="pub-list__year">2026</span>
       <div>
-      <ul class="c-tabs__list_pub">
-          <li>
-            <h4>答案診断グラフを用いた国語記述式問題のための論理構造に基づくフィードバック自動生成</h4>
-            <p> 古橋 萌々香, <u>舟山 弘晃</u>, 松林 優一郎, 震明 万智, 磯部 順子, 石井 雄隆, 乾 健太郎. 自然言語処理, 2026, 33 巻, 1 号, p. 240-282, <i><a href="https://www.jstage.jst.go.jp/article/jnlp/33/1/33_240/_article/-char/ja">[Link]</a></i></p>
-          </li>
-          <li>
-            <h4>Cross-prompt Pre-finetuning of Language Models for Short Answer Scoring</h4>
-            <u> Hiroaki Funayama</u>, Yuichiroh Matsubayashi, Tomoya Mizumoto, Kentaro Inui. 
-            International Journal of Artificial Intelligence in Education (IJAIED), vol. 35, pp. 2399–2420, July, 2025. <a href="https://link.springer.com/article/10.1007/s40593-025-00474-w?utm_source=rct_congratemailt&utm_medium=email&utm_campaign=oa_20250710&utm_content=10.1007/s40593-025-00474-w">[Link]</a>
-            </p>
-          </li>
-          <li>
-              <h4> Automatic feedback generation for short answer questions using answer diagnostic graphs</h4>
-              Momoka Furuhashi, <u> Hiroaki Funayama</u>, Yuya Iwase, Yuichiroh Matsubayashi, Yoriko Isobe, Toru Nagahama, Saku Sugawara, Kentaro Inui.  the 16th annual International Conference on Education and New Learning Technologies (EDULEARN 2024).,to be appear, July. 2024, Majorca. Full paper, reviewed as extended abstract.</p >
-          </li>
-          <li>
-              <h4>Japanese-English Sentence Translation Exercises Dataset for Automatic Grading</h4>
-              <p> Naoki Miura, <u>Hiroaki Funayama</u>>, Seiya Kikuchi, Yuichiroh Matsubayashi, Yuya Iwase, Kentaro Inui. Proceedings of the 18th Conference of the European Chapter of the Association for Computational Linguistics: Student Research Workshop (EACL2024-SRW).,pp266-278 , March. 2024, Malta.</p >
-          </li>
-          <li>
-              <h4>Take No Shortcuts! Stick to the Rubric: A Method for Building Trustworthy Short Answer Scoring Models</h4>
-              <p> Yuya Asazuma, <u>Hiroaki Funayama</u>, Yuichiroh Matsubayashi, Tomoya Mizumoto and Kentaro Inui. 5th International Conference on Higher Education Learning Methodologies and Technologies Online (HELMeTO 2023). , Sept. 2023, oral presentation, Foggia, Italy.</p >
-          </li>
-          <li>
-              <h4>Assessing Step-by-Step Reasoning against Lexical Negation: A Case Study on Syllogism</h4>
-              <p> Mengyu Ye, Tatsuki Kuribayashi, Jun Suzuki, Goro Kobayashi and  <u>Hiroaki Funayama </u>.  The 2023 Conference on Empirical Methods in Natural Language Processing (EMNLP 2023). pp.14753–14773, Dec. 2023, Singapore. </p >
-          </li>
-          <li>
-              <h4>Adhere to the Rubric: A Method for Building Trustworthy Short Answer Scoring Models</h4>
-              <p> Yuya Asazuma, <u>Hiroaki Funayama</u>, Yuichiroh Matsubayashi, Tomoya Mizumoto and Kentaro Inui. 5th International Conference on Higher Education Learning Methodologies and Technologies Online (HELMeTO 2023). pp.108-110 , Sept. 2023, oral presentation, Foggia, Italy. Accepted as extended abstract.  </p >
-          </li>
-          <li>
-              <h4>Assessing Chain-of-Thought Reasoning against Lexical Negation: A Case Study on Syllogism</h4>
-              <p> Mengyu Ye, Tatsuki Kuribayashi, Jun Suzuki, <u>Hiroaki Funayama </u>, and Goro Kobayashi. In the 61st Annual Meeting of the Association for Computational Linguistics Student Research Workshop (ACL-SRW). Non archival submission.<b> Non archival submission</b> </p ><b> Best Paper Award</b>
-          </li>
-          <li>
-              <h4>Reducing the Cost: Cross-Prompt Pre-Finetuning for Short Answer Scoring</h4>
-              <p> <u>Hiroaki Funayama </u>, Yuya Asazuma, Yuichiroh Matsubayashi, Tomoya Mizumoto and Kentaro Inui.  The 24th International Conference on Artificial Intelligence in Education (AIED2023). pp.78-89, July 2023, Oral presentation, Tokyo, Japan, (Accepted as full paper, Acceptance rate: 21.11%, CORE Rank=A). </p> <b> Best Paper Nominee</b>
-          </li>
-          <li>
-              <h4>TohokuNLP at SemEval-2023 Task 5: Clickbait Spoiling via Simple Seq2seq Generation and Ensembling</h4>
-              <p> Hiroto Kurita†, Ikumi Ito†, <u>Hiroaki Funayama</u>, Shota Sasaki, Shoji Moriya,
-                  Ye Mengyu, Kazuma Kokuta, Ryujin Hatakeyama, Shusaku Sone, Kentaro Inui.  The 17th International Workshop on Semantic Evaluation (SemEval-2023). to be appear, July 2023, Oral presentation, Vancouver, Canada, (†Equal contribution) </p> <b> Nominated for Best Paper</b>
-          </li>
-          <li>
-              <h4>Balancing Cost and Quality: An Exploration of Human-in-the-loop Frameworks for Automated Short Answer Scoring</h4>
-              <p> <u>Hiroaki Funayama </u>, Tasuku Sato, Yuichiroh Matsubayashi, Tomoya Mizumoto, Jun Suzuki and Kentaro Inui.  The 23rd International Conference on Artificial Intelligence in Education (AIED2022). pp 465–476, July 2022, Oral presentation, Durham University, UK, <i><a href="https://link.springer.com/chapter/10.1007/978-3-031-11644-5_38">[Link]</a></i>, (Accepted as full paper, Acceptance rate: 40/197 = 20.3%, CORE Rank=A). </p> <b> Best Paper Nominee</b>
-          </li>
-          <li>
-              <h4>Generating Feature Attribution-based Explanations for Automated Short Answer Scoring</h4>
-              <p> Tasuku Sato, <u>Hiroaki Funayama</u>, Kazuaki Hanawa and Kentaro Inui.  The 23rd International Conference on Artificial Intelligence in Education (AIED2022). pp 231–242, July 2022, Oral presentation, Durham University, UK,<i> <a href="https://link.springer.com/chapter/10.1007/978-3-031-11644-5_19">[Link]</a></i>, (Accepted as full paper, Acceptance rate: 40/197 = 20.3%, CORE Rank=A).</p>
-          </li>
-            <li>
-              <h4>Data Augmentation by Rubrics for Short Answer Grading</h4>
-              <p>Tianqi Wang, <u>Hiroaki Funayama</u>, Hiroki Ouchi and Kentaro Inui, Journal of Natural Language Processing Volume 28 Number 1
-                . June 2021</p>
-            </li>
-             <li>
-              <h4>Preventing Critical Scoring Errors in Short Answer Scoring with Confidence Estimation</h4>
-              <p> <u>Hiroaki Funayama </u>, Shota Sasaki, Yuichiro Matsubayashi, Tomoya Mizumoto,
-                        Jun Suzuki, Masato Mita, Kentaro Inui, In the 58th Annual Meeting of the Association for Computational Linguistics Student Research Workshop (ACL-SRW). pp. 237–243, August 2020, Oral presentation (online), <i> <a href="https://www.aclweb.org/anthology/2020.acl-srw.32/">[Link]</a></i>, (Acceptance rate: 72/202=35.6%)</p>
-            </li>
-        </ul>
+        <div class="pub-list__title-ja">答案診断グラフを用いた国語記述式問題のための論理構造に基づくフィードバック自動生成</div>
+        <div class="pub-list__title-en pub-list__title-en--with-ja">Logic-structured feedback generation for Japanese short-answer questions via answer-diagnostic graphs</div>
+        <div class="pub-list__authors">古橋 萌々香, <span class="me">舟山 弘晃</span>, 松林 優一郎, 震明 万智, 磯部 順子, 石井 雄隆, 乾 健太郎</div>
+        <div class="pub-list__venue">自然言語処理 (Journal of Natural Language Processing)<span class="details"> — Vol. 33, No. 1, pp. 240–282</span></div>
+      </div>
+      <div class="pub-list__links">
+        <a class="pub-list__link" href="https://www.jstage.jst.go.jp/article/jnlp/33/1/33_240/_article/-char/ja">Link</a>
+      </div>
+    </li>
+    <li data-type="journal">
+      <span class="pub-list__year">2025</span>
+      <div>
+        <div class="pub-list__title-en">Cross-prompt Pre-finetuning of Language Models for Short Answer Scoring</div>
+        <div class="pub-list__authors"><span class="me">Hiroaki Funayama</span>, Yuichiroh Matsubayashi, Tomoya Mizumoto, Kentaro Inui</div>
+        <div class="pub-list__venue">International Journal of Artificial Intelligence in Education (IJAIED)<span class="details"> — Vol. 35, pp. 2399–2420, July 2025</span></div>
+      </div>
+      <div class="pub-list__links">
+        <a class="pub-list__link" href="https://link.springer.com/article/10.1007/s40593-025-00474-w">Link</a>
+      </div>
+    </li>
+    <li data-type="international">
+      <span class="pub-list__year">2024</span>
+      <div>
+        <div class="pub-list__title-en">Automatic feedback generation for short answer questions using answer diagnostic graphs</div>
+        <div class="pub-list__authors">Momoka Furuhashi, <span class="me">Hiroaki Funayama</span>, Yuya Iwase, Yuichiroh Matsubayashi, Yoriko Isobe, Toru Nagahama, Saku Sugawara, Kentaro Inui</div>
+        <div class="pub-list__venue">EDULEARN 2024 — 16th Int. Conf. on Education and New Learning Technologies<span class="details"> — Majorca. Full paper, peer-reviewed.</span></div>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="international">
+      <span class="pub-list__year">2024</span>
+      <div>
+        <div class="pub-list__title-en">Japanese-English Sentence Translation Exercises Dataset for Automatic Grading</div>
+        <div class="pub-list__authors">Naoki Miura, <span class="me">Hiroaki Funayama</span>, Seiya Kikuchi, Yuichiroh Matsubayashi, Yuya Iwase, Kentaro Inui</div>
+        <div class="pub-list__venue">EACL 2024 — Student Research Workshop<span class="details"> — pp. 266–278, March 2024, Malta.</span></div>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="international">
+      <span class="pub-list__year">2023</span>
+      <div>
+        <div class="pub-list__title-en">Take No Shortcuts! Stick to the Rubric: A Method for Building Trustworthy Short Answer Scoring Models</div>
+        <div class="pub-list__authors">Yuya Asazuma, <span class="me">Hiroaki Funayama</span>, Yuichiroh Matsubayashi, Tomoya Mizumoto, Kentaro Inui</div>
+        <div class="pub-list__venue">HELMeTO 2023 — 5th Int. Conf. on Higher Education Learning Methodologies<span class="details"> — Sept. 2023, oral, Foggia, Italy.</span></div>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="international">
+      <span class="pub-list__year">2023</span>
+      <div>
+        <div class="pub-list__title-en">Assessing Step-by-Step Reasoning against Lexical Negation: A Case Study on Syllogism</div>
+        <div class="pub-list__authors">Mengyu Ye, Tatsuki Kuribayashi, Jun Suzuki, Goro Kobayashi, <span class="me">Hiroaki Funayama</span></div>
+        <div class="pub-list__venue">EMNLP 2023<span class="details"> — pp. 14753–14773, Dec. 2023, Singapore.</span></div>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="international">
+      <span class="pub-list__year">2023</span>
+      <div>
+        <div class="pub-list__title-en">Adhere to the Rubric: A Method for Building Trustworthy Short Answer Scoring Models</div>
+        <div class="pub-list__authors">Yuya Asazuma, <span class="me">Hiroaki Funayama</span>, Yuichiroh Matsubayashi, Tomoya Mizumoto, Kentaro Inui</div>
+        <div class="pub-list__venue">HELMeTO 2023<span class="details"> — pp. 108–110, Sept. 2023, oral, Foggia, Italy. Extended abstract.</span></div>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="international">
+      <span class="pub-list__year">2023</span>
+      <div>
+        <div class="pub-list__title-en">Assessing Chain-of-Thought Reasoning against Lexical Negation: A Case Study on Syllogism</div>
+        <div class="pub-list__authors">Mengyu Ye, Tatsuki Kuribayashi, Jun Suzuki, <span class="me">Hiroaki Funayama</span>, Goro Kobayashi</div>
+        <div class="pub-list__venue">ACL Student Research Workshop (ACL-SRW)<span class="details"> — Non-archival submission.</span></div>
+        <span class="pub-list__badge">Best Paper Award</span>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="international">
+      <span class="pub-list__year">2023</span>
+      <div>
+        <div class="pub-list__title-en">Reducing the Cost: Cross-Prompt Pre-Finetuning for Short Answer Scoring</div>
+        <div class="pub-list__authors"><span class="me">Hiroaki Funayama</span>, Yuya Asazuma, Yuichiroh Matsubayashi, Tomoya Mizumoto, Kentaro Inui</div>
+        <div class="pub-list__venue">AIED 2023 — 24th Int. Conf. on Artificial Intelligence in Education<span class="details"> — pp. 78–89, July 2023, oral, Tokyo. Full paper (acceptance 21.11%, CORE A).</span></div>
+        <span class="pub-list__badge">Best Paper Nominee</span>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="international">
+      <span class="pub-list__year">2023</span>
+      <div>
+        <div class="pub-list__title-en">TohokuNLP at SemEval-2023 Task 5: Clickbait Spoiling via Simple Seq2seq Generation and Ensembling</div>
+        <div class="pub-list__authors">Hiroto Kurita†, Ikumi Ito†, <span class="me">Hiroaki Funayama</span>, Shota Sasaki, Shoji Moriya, Mengyu Ye, Kazuma Kokuta, Ryujin Hatakeyama, Shusaku Sone, Kentaro Inui</div>
+        <div class="pub-list__venue">SemEval-2023 — 17th Int. Workshop on Semantic Evaluation<span class="details"> — July 2023, oral, Vancouver. (†equal contribution)</span></div>
+        <span class="pub-list__badge">Nominated for Best Paper</span>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="international">
+      <span class="pub-list__year">2022</span>
+      <div>
+        <div class="pub-list__title-en">Balancing Cost and Quality: An Exploration of Human-in-the-loop Frameworks for Automated Short Answer Scoring</div>
+        <div class="pub-list__authors"><span class="me">Hiroaki Funayama</span>, Tasuku Sato, Yuichiroh Matsubayashi, Tomoya Mizumoto, Jun Suzuki, Kentaro Inui</div>
+        <div class="pub-list__venue">AIED 2022 — 23rd Int. Conf. on Artificial Intelligence in Education<span class="details"> — pp. 465–476, July 2022, oral, Durham, UK. Full paper (acceptance 20.3%, CORE A).</span></div>
+        <span class="pub-list__badge">Best Paper Nominee</span>
+      </div>
+      <div class="pub-list__links">
+        <a class="pub-list__link" href="https://link.springer.com/chapter/10.1007/978-3-031-11644-5_38">Link</a>
+      </div>
+    </li>
+    <li data-type="international">
+      <span class="pub-list__year">2022</span>
+      <div>
+        <div class="pub-list__title-en">Generating Feature Attribution-based Explanations for Automated Short Answer Scoring</div>
+        <div class="pub-list__authors">Tasuku Sato, <span class="me">Hiroaki Funayama</span>, Kazuaki Hanawa, Kentaro Inui</div>
+        <div class="pub-list__venue">AIED 2022<span class="details"> — pp. 231–242, July 2022, oral, Durham, UK. Full paper (acceptance 20.3%, CORE A).</span></div>
+      </div>
+      <div class="pub-list__links">
+        <a class="pub-list__link" href="https://link.springer.com/chapter/10.1007/978-3-031-11644-5_19">Link</a>
+      </div>
+    </li>
+    <li data-type="journal">
+      <span class="pub-list__year">2021</span>
+      <div>
+        <div class="pub-list__title-en">Data Augmentation by Rubrics for Short Answer Grading</div>
+        <div class="pub-list__authors">Tianqi Wang, <span class="me">Hiroaki Funayama</span>, Hiroki Ouchi, Kentaro Inui</div>
+        <div class="pub-list__venue">Journal of Natural Language Processing<span class="details"> — Vol. 28, No. 1, June 2021.</span></div>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="international">
+      <span class="pub-list__year">2020</span>
+      <div>
+        <div class="pub-list__title-en">Preventing Critical Scoring Errors in Short Answer Scoring with Confidence Estimation</div>
+        <div class="pub-list__authors"><span class="me">Hiroaki Funayama</span>, Shota Sasaki, Yuichiro Matsubayashi, Tomoya Mizumoto, Jun Suzuki, Masato Mita, Kentaro Inui</div>
+        <div class="pub-list__venue">ACL Student Research Workshop (ACL-SRW)<span class="details"> — pp. 237–243, Aug. 2020, oral (online). Acceptance 35.6%.</span></div>
+      </div>
+      <div class="pub-list__links">
+        <a class="pub-list__link" href="https://www.aclweb.org/anthology/2020.acl-srw.32/">Link</a>
+      </div>
+    </li>
+    <li data-type="domestic">
+      <span class="pub-list__year">2024</span>
+      <div>
+        <div class="pub-list__title-ja">国語記述問題自動採点システムの開発と評価</div>
+        <div class="pub-list__authors">石井 雄隆, <span class="me">舟山 弘晃</span>, 松林 優一郎, 乾 健太郎</div>
+        <div class="pub-list__venue">日本教育工学会研究報告書<span class="details"> — 2024 巻 1 号</span></div>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="domestic">
+      <span class="pub-list__year">2024</span>
+      <div>
+        <div class="pub-list__title-ja">大規模言語モデルによる和文英訳問題の自動採点</div>
+        <div class="pub-list__authors">三浦 直己, <span class="me">舟山 弘晃</span>, 松林 優一郎, 岩瀬 裕哉, 乾 健太郎</div>
+        <div class="pub-list__venue">言語処理学会第30回年次大会 (NLP2024)<span class="details"> — 2024年3月, 神戸, ポスター発表</span></div>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="domestic">
+      <span class="pub-list__year">2024</span>
+      <div>
+        <div class="pub-list__title-ja">答案診断グラフを用いた国語記述式答案へのフィードバックの生成</div>
+        <div class="pub-list__authors">古橋 萌々香, <span class="me">舟山 弘晃</span>, 岩瀬 裕哉, 松林 優一郎, 磯部 順子, 菅原 朔, 乾 健太郎</div>
+        <div class="pub-list__venue">言語処理学会第30回年次大会 (NLP2024)<span class="details"> — 2024年3月, 神戸, 口頭発表</span></div>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="domestic">
+      <span class="pub-list__year">2023</span>
+      <div>
+        <div class="pub-list__title-ja">大規模言語モデルによる和文英訳問題の自動採点の評価と応用可能性の検討</div>
+        <div class="pub-list__authors">三浦 直己, 岩瀬 裕哉, <span class="me">舟山 弘晃</span>, 松林 優一郎</div>
+        <div class="pub-list__venue">NLP若手の会 第18回シンポジウム (YANS 2023)<span class="details"> — 2023年8月, 東京, ポスター発表</span></div>
+        <span class="pub-list__badge">奨励賞受賞</span>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="domestic">
+      <span class="pub-list__year">2023</span>
+      <div>
+        <div class="pub-list__title-ja">次世代教育のための論理的思考力育成データセットの生成について</div>
+        <div class="pub-list__authors">古橋 萌々香, 松林 優一郎, 磯部 順子, <span class="me">舟山 弘晃</span>, 乾 健太郎</div>
+        <div class="pub-list__venue">NLP若手の会 第18回シンポジウム (YANS 2023)<span class="details"> — 2023年8月, 東京, ポスター発表</span></div>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="journal">
+      <span class="pub-list__year">2022</span>
+      <div>
+        <div class="pub-list__title-ja">自然言語処理×教育における説明能力 ―説明できるライティング評価技術への新しい展開―</div>
+        <div class="pub-list__authors">乾 健太郎, 石井 雄隆, 松林 優一郎, 井之上 直也, 内藤 昭一, 磯部 順子, <span class="me">舟山 弘晃</span>, 菊地 正弥</div>
+        <div class="pub-list__venue">電子情報通信学会 基礎・境界ソサイエティ Fundamentals Review<span class="details"> — 16 巻 4 号, pp. 289–300, 2022</span></div>
+      </div>
+      <div class="pub-list__links">
+        <a class="pub-list__link" href="https://www.jstage.jst.go.jp/article/essfr/16/4/16_289/_article/-char/ja">Link</a>
+      </div>
+    </li>
+    <li data-type="domestic">
+      <span class="pub-list__year">2023</span>
+      <div>
+        <div class="pub-list__title-en">What can Short Answer Scoring Models Learn from Cross-prompt Training Data?</div>
+        <div class="pub-list__authors"><span class="me">Hiroaki Funayama</span>, Yuya Asazuma, Yuichiroh Matsubayashi, Tomoya Mizumoto, Kentaro Inui</div>
+        <div class="pub-list__venue">言語処理学会第29回年次大会 (NLP2023)<span class="details"> — 2023年3月, 沖縄, 口頭発表</span></div>
+        <span class="pub-list__badge">委員特別賞受賞</span>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="domestic">
+      <span class="pub-list__year">2023</span>
+      <div>
+        <div class="pub-list__title-ja">記述式答案採点モデルの採点基準に対する整合性の検証</div>
+        <div class="pub-list__authors">浅妻 佑弥, <span class="me">舟山 弘晃</span>, 松林 優一郎, 水本 智也, 乾 健太郎</div>
+        <div class="pub-list__venue">言語処理学会第29回年次大会 (NLP2023)<span class="details"> — 2023年3月, 沖縄, 口頭発表</span></div>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="domestic">
+      <span class="pub-list__year">2023</span>
+      <div>
+        <div class="pub-list__title-ja">文章構造グラフを用いた国語記述式答案への自動フィードバック生成</div>
+        <div class="pub-list__authors">岩瀬 裕哉, <span class="me">舟山 弘晃</span>, 松林 優一郎, 乾 健太郎</div>
+        <div class="pub-list__venue">言語処理学会第29回年次大会 (NLP2023)<span class="details"> — 2023年3月, 沖縄, 口頭発表</span></div>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="domestic">
+      <span class="pub-list__year">2023</span>
+      <div>
+        <div class="pub-list__title-ja">思考連鎖指示における大規模言語モデルの否定表現理解</div>
+        <div class="pub-list__authors">葉 夢宇, 栗林 樹生, <span class="me">舟山 弘晃</span>, 鈴木 潤</div>
+        <div class="pub-list__venue">言語処理学会第29回年次大会 (NLP2023)<span class="details"> — 2023年3月, 沖縄, 口頭発表</span></div>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="domestic">
+      <span class="pub-list__year">2022</span>
+      <div>
+        <div class="pub-list__title-ja">説明可能なAIを指向した和文英訳自動採点システムの開発と評価</div>
+        <div class="pub-list__authors">石井 雄隆, 菊地 正弥, <span class="me">舟山 弘晃</span>, 松林 優一郎, 乾 健太郎</div>
+        <div class="pub-list__venue">2022年第4回 日本教育工学会研究会<span class="details"> — 2022年12月</span></div>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="domestic">
+      <span class="pub-list__year">2022</span>
+      <div>
+        <div class="pub-list__title-ja">日本語学習者支援のための敬語変換タスクの提案</div>
+        <div class="pub-list__authors">松本 悠太, 林崎 由, 北山 晃太郎, <span class="me">舟山 弘晃</span>, 三田 雅人, 乾 健太郎</div>
+        <div class="pub-list__venue">第36回 人工知能学会全国大会 (JSAI2022)<span class="details"> — 2022年6月, 京都, ポスター発表</span></div>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="domestic">
+      <span class="pub-list__year">2022</span>
+      <div>
+        <div class="pub-list__title-ja">記述式答案自動採点における確信度推定とその役割</div>
+        <div class="pub-list__authors"><span class="me">舟山 弘晃</span>, 佐藤 汰亮, 松林 優一郎, 水本 智也, 鈴木 潤, 乾 健太郎</div>
+        <div class="pub-list__venue">言語処理学会第28回年次大会 (NLP2022)<span class="details"> — 2022年3月, オンライン</span></div>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="domestic">
+      <span class="pub-list__year">2022</span>
+      <div>
+        <div class="pub-list__title-ja">根拠箇所に基づく自動採点結果の説明</div>
+        <div class="pub-list__authors">佐藤 汰亮, <span class="me">舟山 弘晃</span>, 塙 一晃, 浅妻 佑弥, 乾 健太郎</div>
+        <div class="pub-list__venue">言語処理学会第28回年次大会 (NLP2022)<span class="details"> — 2022年3月, オンライン</span></div>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="domestic">
+      <span class="pub-list__year">2021</span>
+      <div>
+        <div class="pub-list__title-en">Incorporating Rubrics to Short Answer Grading</div>
+        <div class="pub-list__authors">王 天奇, <span class="me">舟山 弘晃</span>, 大内 啓樹, 乾 健太郎</div>
+        <div class="pub-list__venue">言語処理学会第27回年次大会 (NLP2021)<span class="details"> — 2021年3月, オンライン</span></div>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="domestic">
+      <span class="pub-list__year">2021</span>
+      <div>
+        <div class="pub-list__title-ja">項目採点技術に基づいた和文英訳答案の自動採点</div>
+        <div class="pub-list__authors">菊地 正弥*, 尾中 大介*, <span class="me">舟山 弘晃*</span>, 松林 優一郎, 乾 健太郎</div>
+        <div class="pub-list__venue">言語処理学会第27回年次大会 (NLP2021)<span class="details"> — 2021年3月, オンライン (*equal contribution)</span></div>
+        <span class="pub-list__badge">委員特別賞受賞</span>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="domestic">
+      <span class="pub-list__year">2021</span>
+      <div>
+        <div class="pub-list__title-ja">実用的な自動採点のための確信度推定と根拠事例の提供</div>
+        <div class="pub-list__authors"><span class="me">舟山 弘晃</span>, 王 天奇, 松林 優一郎, 水本 智也, 佐藤 汰亮, 鈴木 潤, 乾 健太郎</div>
+        <div class="pub-list__venue">NLP2021 ワークショップ「文章の評価と品質推定」<span class="details"> — 2021年3月, ポスター発表</span></div>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="domestic">
+      <span class="pub-list__year">2020</span>
+      <div>
+        <div class="pub-list__title-ja">国語記述式答案自動採点の現状と実応用に向けて</div>
+        <div class="pub-list__authors"><span class="me">舟山 弘晃</span></div>
+        <div class="pub-list__venue">教育アセスメント×言語処理シンポジウム<span class="details"> — 2020年11月</span></div>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="domestic">
+      <span class="pub-list__year">2020</span>
+      <div>
+        <div class="pub-list__title-ja">記述式答案自動採点のための確信度推定手法の検討</div>
+        <div class="pub-list__authors"><span class="me">舟山 弘晃</span>, 佐々木 翔大, 水本 智也, 三田 雅人, 鈴木 潤, 乾 健太郎</div>
+        <div class="pub-list__venue">言語処理学会第26回年次大会<span class="details"> — 2020年3月, 口頭発表 (オンライン)</span></div>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="domestic">
+      <span class="pub-list__year">2019</span>
+      <div>
+        <div class="pub-list__title-ja">自動採点のための確信度推定手法</div>
+        <div class="pub-list__authors"><span class="me">舟山 弘晃</span>, 佐々木 翔大, 水本 智也, 三田 雅人, 鈴木 潤, 乾 健太郎</div>
+        <div class="pub-list__venue">NLP若手の会 第14回シンポジウム (YANS 2019)<span class="details"> — 2019年8月, 札幌, ポスター発表</span></div>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+    <li data-type="domestic">
+      <span class="pub-list__year">2019</span>
+      <div>
+        <div class="pub-list__title-ja">seq2seqによる部首を考慮したニューラル漢字生成システム</div>
+        <div class="pub-list__authors">藤井 諒, <span class="me">舟山 弘晃</span>, 北山 晃太郎, 阿部 香央莉, Ana Brassard, 三田 雅人, 大内 啓樹</div>
+        <div class="pub-list__venue">NLP若手の会 第14回シンポジウム (YANS 2019)<span class="details"> — 2019年8月, 札幌, ポスター発表</span></div>
+      </div>
+      <div class="pub-list__links"></div>
+    </li>
+  </ol>
+</section>
+
+<!-- ============================ TALKS ============================ -->
+<section class="section section--panel" id="talks">
+  <div class="section-title">
+    <h2 class="section-title__en">Talks</h2>
+    <span class="section-title__ja">講演</span>
+    <span class="section-title__rule"></span>
+  </div>
+
+  <ul class="talks-list">
+    <li>
+      <span class="talks-list__date">2025 · Jun</span>
+      <div>
+        <div class="talks-list__title">人とAIが協働する記述式答案自動採点フレームワークの探究: 研究成果と社会実装の展望</div>
+        <div class="talks-list__venue">AIP自然言語理解チーム ワークショップ：教育 × NLPの深化と未来</div>
+      </div>
+      <div class="talks-list__meta">
+        <span>Workshop</span>
+        <a href="https://c5dc59ed978213830355fc8978.doorkeeper.jp/events/184325">Link</a>
+      </div>
+    </li>
+    <li>
+      <span class="talks-list__date">2023 · Sep</span>
+      <div>
+        <div class="talks-list__title talks-list__title--en">Toward Practical Use of Automated Short Answer Scoring: Challenges and Prospects</div>
+        <div class="talks-list__venue">HeKKSaGOn AI Symposium, Göttingen (Germany)</div>
+      </div>
+      <div class="talks-list__meta">
+        <span>Symposium</span>
+        <a href="https://events.gwdg.de/event/437/timetable/#24-toward-practical-use-of-aut">Link</a>
+      </div>
+    </li>
+    <li>
+      <span class="talks-list__date">2023 · Sep</span>
+      <div>
+        <div class="talks-list__title">採点コストと採点品質の最適化に向けたSASにおける人間参加型フレームワークの探求</div>
+        <div class="talks-list__venue">第22回科学技術フォーラム (FIT2023) トップコンファレンスセッション 教育学習支援情報システム, 大阪</div>
+      </div>
+      <div class="talks-list__meta">
+        <span>Conference</span>
+        <a href="https://www.ipsj.or.jp/event/fit/fit2023/abstract/data/html/event/event_TCS2-2.html">Link</a>
+      </div>
+    </li>
+    <li>
+      <span class="talks-list__date">2023 · Jan</span>
+      <div>
+        <div class="talks-list__title">記述式答案自動採点の実現に向けて — 現在の技術と今後の展望</div>
+        <div class="talks-list__venue">東北大学 学問論演習2023, 仙台</div>
+      </div>
+      <div class="talks-list__meta">
+        <span>Lecture</span>
+      </div>
+    </li>
+    <li>
+      <span class="talks-list__date">2020 · Nov</span>
+      <div>
+        <div class="talks-list__title">国語記述式答案自動採点の現状と実応用に向けて</div>
+        <div class="talks-list__venue">教育アセスメント×言語処理シンポジウム — 自動採点、英文添削、論述評価の可能</div>
+      </div>
+      <div class="talks-list__meta">
+        <span>Symposium</span>
+        <a href="https://c5dc59ed978213830355fc8978.doorkeeper.jp/events/113005">Link</a>
+      </div>
+    </li>
+  </ul>
+</section>
+
+<!-- ============================ EXPERIENCE & EDUCATION ============================ -->
+<section class="section">
+  <div class="exp-edu">
+    <div id="experience">
+      <div class="section-title">
+        <h2 class="section-title__en">Experience</h2>
+        <span class="section-title__ja">経歴</span>
+        <span class="section-title__rule"></span>
+      </div>
+      <ul class="timeline">
+        <li>
+          <span class="timeline__date">2025.7 — Current</span>
+          <div>
+            <div class="timeline__primary">Graduate School of Information Sciences (GSIS), Tohoku University</div>
+            <div class="timeline__secondary">Part-time Researcher (学術研究員)</div>
           </div>
-      <div class="c-section-sub_heading">
-        <h3 class="c-section-heading__header">Domestic Conference and Symposium</h3>
-      </div>
-  <div>
-
-    <ul class="c-tabs__list_pub">
-        <li>
-            <h4>国語記述問題自動採点システムの開発と評価</h4>
-            <p> 石井雄隆， <u>舟山弘晃</u>， 松林優一郎， 乾健太郎. 日本教育工学会研究報告書, 2024巻1号</p>
         </li>
         <li>
-            <h4>大規模言語モデルによる和文英訳問題の自動採点</h4>
-            <p> 三浦直己, <u>舟山弘晃</u>, 松林優一郎, 岩瀬裕哉, 乾健太郎. 言語処理学会第30回年次大会 (NLP2024), 2024 年 3 ⽉, 神戸, ポスター発表.</p>
-        </li>
-        <li>
-            <h4>答案診断グラフを用いた国語記述式答案へのフィードバックの生成</h4>
-            <p> 古橋萌々香, <u>舟山弘晃</u>, 岩瀬裕哉, 松林優一郎, 磯部順子, 菅原朔, 乾健太郎. 言語処理学会第30回年次大会 (NLP2024), 2024 年 3 ⽉, 神戸, 口頭発表.</p>
-        </li>
-        <li>
-            <h4>大規模言語モデルによる和文英訳問題の自動採点の評価と応用可能性の検討</h4>
-            <p> 三浦直己，岩瀬裕哉，<u>舟山弘晃</u>，松林優一郎. NLP若手の会第18回シンポジウム（YANS 2023）, 2023 年 8 ⽉, 東京, ポスター発表. <br> <b>奨励賞受賞</b></p>
-        </li>
-        <li>
-            <h4>次世代教育のための論理的思考力育成データセットの生成について</h4>
-            <p> 古橋萌々香, 松林 優一郎, 磯部 順子, <u>舟山弘晃</u>, 乾健太郎. NLP若手の会第18回シンポジウム（YANS 2023）, 2023 年 8 ⽉, 東京, ポスター発表</p>
-        </li>
-                    <li>
-                        <h4>自然言語処理×教育における説明能力 ―説明できるライティング評価技術への新しい展開―</h4>
-                        <p> 乾 健太郎, 石井 雄隆, 松林 優一郞, 井之上 直也, 内藤 昭一, 磯部 順子, <u>舟山 弘晃</u>, 菊地 正弥. 電子情報通信学会 基礎・境界ソサイエティ Fundamentals Review, 2022, 16 巻, 4 号, p. 289-300,<i> <a href="https://www.jstage.jst.go.jp/article/essfr/16/4/16_289/_article/-char/ja">[Link]</a></i></p>
-                    </li>
-                     <li>
-                    <h4>What can Short Answer Scoring Models Learn from Cross-prompt Training Data?</h4>
-                    <p> <u>Hiroaki Funayama</u>, Yuya Asazuma, Yuichiroh Matsubayashi, Tomoya Mizumoto, Kentaro Inui. ⾔語処理学会第 29 回年次⼤会（NLP2023)， 沖縄, 口頭発表, 2023 年 3⽉. <br> <b> 委員特別賞受賞</b></p>
-                    </li>
-                    <li>
-                        <h4>記述式答案採点モデルの採点基準に対する整合性の検証</h4>
-                        <p> 浅妻佑弥, <u>舟山弘晃</u>, 松林優一郎, 水本智也, 乾健太郎. ⾔語処理学会第 29 回年次⼤会（NLP2023)， 沖縄, 口頭発表, 2023 年 3⽉</p>
-                    </li>
-                    <li>
-                        <h4>文章構造グラフを用いた国語記述式答案への自動フィードバック生成</h4>
-                        <p> 岩瀬裕哉, <u>舟山弘晃</u>, 松林優一郎, 乾健太郎. ⾔語処理学会第 29 回年次⼤会（NLP2023)， 沖縄, 口頭発表, 2023 年 3⽉</p>
-                    </li>
-                    <li>
-                        <h4>思考連鎖指示における大規模言語モデルの否定表現理解</h4>
-                        <p>葉夢宇, 栗林樹生, <u>舟山弘晃</u>, 鈴木潤. ⾔語処理学会第 29 回年次⼤会（NLP2023)， 沖縄, 口頭発表, 2023 年 3⽉</p>
-                    </li>
-                <li>
-                    <h4>説明可能なAIを指向した和文英訳自動採点システムの開発と評価</h4>
-                    <p> 石井雄隆, 菊地正弥, <u>舟山弘晃</u>, 松林優一郎 乾健太郎. 2022年第4回日本教育工学会研究会， 2022 年 12 ⽉</p>
-                </li>
-                <li>
-                    <h4>日本語学習者支援のための敬語変換タスクの提案</h4>
-                    <p> 松本 悠太 , 林崎 由, 北山 晃太郎, <u>舟山 弘晃</u>, 三田 雅人, 乾健太郎. 第36回人工知能学会 全国大会（JSAI2022)，京都，2022 年 6 ⽉, ポスター発表</p>
-                </li>
-               <li>
-                <h4>記述式答案自動採点における確信度推定とその役割</h4>
-                <p> <u>舟山弘晃 </u>, 佐藤汰亮, 松林優一郎, 水本智也, 鈴木潤, 乾健太郎. ⾔語処理学会第 28 回年次⼤会（NLP2022) ，オンライン，2022 年 3 ⽉</p>
-              </li>
-              <li>
-                <h4>根拠箇所に基づく自動採点結果の説明</h4>
-                <p>佐藤汰亮, <u>舟山弘晃 </u>,, 塙一晃, 浅妻佑弥, 乾健太郎. ⾔語処理学会第 28 回年次⼤会（NLP2022) ，オンライン，2022 年 3 ⽉</p>
-              </li>
-              <li>
-                <h4>Incorporating Rubrics to Short Answer Grading</h4>
-                <p> 王天奇,  <u>⾈⼭弘晃 </u>,  ⼤内啓樹,  乾健太郎. ⾔語処理学会第 27 回年次⼤会（NLP2021) ，オンライン，2021 年 3 ⽉</p>
-              </li>
-              <li>
-                <h4>項⽬採点技術に基づいた和⽂英訳答案の⾃動採点</h4>
-                <p>菊地正弥*,  尾中⼤介*, <u> ⾈⼭弘晃*</u> ,  松林優⼀郎,  乾健太郎.   ⾔語処理学会第 27 回年次⼤会 (NLP2021), オンライン，2021 年 3 ⽉, *はequal contribution. <br> <b> 委員特別賞受賞</b>, </p>
-              </li>
-              <li>
-                <h4>実⽤的な⾃動採点のための確信度推定と根拠事例の提供</h4>
-                <p> <u> ⾈⼭弘晃 </u> ，王天奇，松林優⼀郎，⽔本智也，佐藤汰亮，鈴⽊潤，乾健太郎. NLP2021 ワークショップ ⽂章の評価と品質推定 〜⼈間・機械の「作⽂」の巧拙をどう⾒極めるか︖〜, 2021 年 3 ⽉, ポスター発表 </p>
-              </li>
-              <li>
-                <h4>国語記述式答案⾃動採点の現状と実応⽤に向けて</h4>
-                <p><u> ⾈⼭弘晃</u> . 教育アセスメント×⾔語処理シン ポジウム : ⾃動採点、英⽂添削、論述評価の可能，2020 年 11 ⽉</p>
-              </li>
-              <li>
-                <h4>記述式答案自動採点のための確信度推定手法の検討</h4>
-                <p><u> 舟山 弘晃</u> , 佐々木翔大, 水本智也, 三田雅人, 鈴木潤, 乾健太郎.言語処理学会第26回年次大会, March 2020, 口頭発表(オンライン) </p>
-              </li>
-              <li>
-                <h4>自動採点のための確信度推定手法</h4>
-                <p><u> 舟山 弘晃</u>, 佐々木翔大, 水本智也, 三田雅人, 鈴木潤, 乾健太郎. NLP若手の会第14回シンポジウム（YANS 2019）, 札幌, August 2019, ポスター発表</p>
-              </li>
-              <li>
-                <h4>seq2seqによる部首を考慮したニューラル漢字生成システム</h4>
-                <p>藤井諒, <u> 舟山弘晃</u>, 北山晃太郎, 阿部香央莉, Ana brassard, 三田雅人, 大内啓樹. NLP若手の会第14回シンポジウム（YANS 2019）, 札幌, August 2019, ポスター発表
-</p>
-              </li>
-        </ul>
-      </div>
-
-  </div>
-
-    <div id="section-talks" class="o-container wow1 fadeIn" data-contentPosition="3">
-
-        <div class="c-section-heading">
-            <!--      <svg class="c-section-heading__icon svg-icon" xmlns="http://www.w3.org/2000/svg" width="91" height="91" viewBox="0 0 91 91">-->
-            <!--        <rect class="svg-icon__border" x="0.5" y="0.5" width="90" height="90"/>-->
-            <!--        <path class="svg-icon__item" d="M436.894,3644.08v41.3h-32.8v-41.3h4.25v-1.05a1.437,1.437,0,0,1,.35-1.02,1.091,1.091,0,0,1,.9-0.35,1.151,1.151,0,0,1,.875.4,1.5,1.5,0,0,1,.325,1.02v1h1.2v-1.05a1.42,1.42,0,0,1,.325-0.97,1.1,1.1,0,0,1,.875-0.38,1.179,1.179,0,0,1,.9.38,1.437,1.437,0,0,1,.35,1.02v0.95h1.2v-1.1a1.209,1.209,0,0,1,.35-0.9,1.231,1.231,0,0,1,.85-0.37,1.092,1.092,0,0,1,.85.3,1.112,1.112,0,0,1,.35.87l0.05,1.2h1.2v-0.55a2.417,2.417,0,0,1,.3-1.37,1.08,1.08,0,0,1,.925-0.45,0.916,0.916,0,0,1,.9.42,2.774,2.774,0,0,1,.275,1.4v0.55h1.25v-1.05a1.635,1.635,0,0,1,.375-0.97,0.994,0.994,0,0,1,.85-0.35,1.126,1.126,0,0,1,.85.4,1.635,1.635,0,0,1,.375.97v1.05h1.2v-1.1a1.28,1.28,0,0,1,.35-0.95,1.207,1.207,0,0,1,1.7,0,1.393,1.393,0,0,1,.4.9v1.15h1.2v-1.15a1.209,1.209,0,0,1,.35-0.9,1.231,1.231,0,0,1,.85-0.37,1.092,1.092,0,0,1,.85.3,1.112,1.112,0,0,1,.35.87v1.25h4.25Zm-26.5,10.75a1.018,1.018,0,0,0-.3.75,0.921,0.921,0,0,0,.325.73,1.327,1.327,0,0,0,.875.27h18.75a0.938,0,0,0,.85-0.8,1.025,1.025,0,0,0-.2-0.9,1.131,1.131,0,0,0-.9-0.35h-18.6A1.082,1.082,0,0,0,410.394,3654.83Zm0,4.15a1.018,1.018,0,0,0-.3.75,0.921,0.921,0,0,0,.325.73,1.327,1.327,0,0,0,.875.27h18.75a0.96,0.96,0,0,0,.85-0.8,0.983,0.983,0,0,0-.225-0.9,1.148,1.148,0,0,0-.875-0.35h-18.6A1.082,1.082,0,0,0,410.394,3658.98Zm0,12.53a1.057,1.057,0,0,0,.025,1.5,1.327,1.327,0,0,0,.875.27l18.75-.05a0.776,0.776,0,0,0,.575-0.22,1.007,1.007,0,0,0,.275-0.58,0.983,0.983,0,0,0-.225-0.9,1.021,1.021,0,0,0-.875-0.3l-13.85-.05h-4.75A1.291,1.291,0,0,0,410.394,3671.51Zm20.25,5.62a1.018,1.018,0,0,0,.3-0.75,0.888,0.888,0,0,0-.325-0.72,1.359,1.359,0,0,0-.925-0.28h-18.7a0.938,0.938,0,0,0-.85.8,0.89,0.89,0,0,0,.175.9,1.212,1.212,0,0,0,.925.35h18.6A1.082,1.082,0,0,0,430.644,3677.13Zm0-8.32a0.987,0.987,0,0,0,.3-0.75,0.921,0.921,0,0,0-.325-0.75,1.359,1.359,0,0,0-.925-0.28h-18.7a0.972,0.972,0,0,0-.575.28,1.3,1.3,0,0,0-.325.57,1.086,1.086,0,0,0,.25.85,1.131,1.131,0,0,0,.9.35h18.6A1.151,1.151,0,0,0,430.644,3668.81Zm0-4.18a1.048,1.048,0,0,0,.3-0.77,0.868,0.868,0,0,0-.325-0.73,1.47,1.47,0,0,0-.925-0.25h-18.7a1.072,1.072,0,0,0-.575.25,1.132,1.132,0,0,0-.325.55,0.983,0.983,0,0,0,.225.9,1.212,1.212,0,0,0,.925.35h18.6A1.082,1.082,0,0,0,430.644,3664.63Z" transform="translate(-374.5 -3619.5)"/>-->
-    <!--      </svg>-->
-      <h2 class="c-section-heading__header">Activities</h2>
-        </div>
-
-        <div class="c-section-sub_heading">
-            <h3 class="c-section-heading__header">Talk</h3>
-
-        </div>
-        <ul class="c-tabs__list_talk">
-              <li>
-                <h4>人とAIが協働する記述式答案自動採点フレームワークの探究: 研究成果と社会実装の展望</h4>
-                <p>AIP自然言語理解チーム ワークショップ：教育 × NLPの深化と未来 ，2025年6月. <a href="https://c5dc59ed978213830355fc8978.doorkeeper.jp/events/184325">[Link]</a></p>
-            </li>
-            <li>
-                <h4>Toward Practical Use of Automated Short Answer Scoring: Challenges and Prospects</h4>
-                <p>HeKKSaGOn AI Symposium, Göttingen (Germany) ，Sept. 2023. <a href="https://events.gwdg.de/event/437/timetable/#24-toward-practical-use-of-aut">[Link]</a></p>
-            </li>
-            <li>
-                <h4>採点コストと採点品質の最適化に向けたSASにおける人間参加型フレームワークの探求</h4>
-                <p>第22回科学技術フォーラム (FIT2023) トップコンファレンスセッション 教育学習支援情報システム,
-                    大阪，2023 年 9 ⽉. <a href="https://www.ipsj.or.jp/event/fit/fit2023/abstract/data/html/event/event_TCS2-2.html">[Link]</a></p>
-            </li>
-            <li>
-                <h4>記述式答案自動採点の実現に向けて - 現在の技術と今後の展望</h4>
-                <p>東北大学 学問論演習2023, 仙台，2023 年 1 ⽉</p>
-            </li>
-            <li>
-                <h4>国語記述式答案⾃動採点の現状と実応⽤に向けて</h4>
-                <p>教育アセスメント×⾔語処理シンポジウム : ⾃動採点、英⽂添削、論述評価の可能，2020 年 11 ⽉. <a href="https://c5dc59ed978213830355fc8978.doorkeeper.jp/events/113005">[Link]</a></p>
-            </li>
-        </ul>
-
-    </div>
-
-<!-- Activities -->
-  <div id="section-activities" class="o-container js-main-container wow1 fadeIn" data-contentPosition="4">
-    <div class="c-section-heading">
-<!--      <svg class="c-section-heading__icon svg-icon" xmlns="http://www.w3.org/2000/svg" width="91" height="91" viewBox="0 0 91 91">-->
-<!--        <rect class="svg-icon__border" x="0.5" y="0.5" width="90" height="90"/>-->
-<!--        <path class="svg-icon__item" d="M441.844,1714.1a3.587,3.587,0,0,1-1.175,2.18,4.8,4.8,0,0,1-2.425,1.12,9.54,9.54,0,0,1-1.5.1,12.291,12.291,0,0,1-1.5,0h-30a5.209,5.209,0,0,1-2.25-.45,3.054,3.054,0,0,1-1.65-1.7,4.191,4.191,0,0,1-.05-2.65,14.023,14.023,0,0,1,.75-1.75l10.95-20.3a2.556,2.556,0,0,0,.25-1.05v-4.65a0.605,0.605,0,0,0-.075-0.35,0.574,0.574,0,0,0-.375-0.15,3.05,3.05,0,0,1-2.175-.97,3.2,3.2,0,0,1-.875-2.28l-0.05-1.65c0.033-.27.067-0.53,0.1-0.8a3.232,3.232,0,0,1,1.125-1.87,3.119,3.119,0,0,1,2.075-.73h16.25a3.213,3.213,0,0,1,2.4.98,3.157,3.157,0,0,1,.9,2.42c0-.5.017-0.12,0.05,1.15a6.137,6.137,0,0,1-.1,1.2,3.257,3.257,0,0,1-1.075,1.8,3.076,3.076,0,0,1-1.925.75,0.574,0.574,0,0,0-.375.15,0.605,0.605,0,0,0-.075.35v4.85a1.7,1.7,0,0,0,.3.8l11.8,20.4a4.6,4.6,0,0,1,.7,3.1h0Zm-2.425.05a4.446,4.446,0,0,0-.675-2.25l-11.2-20.85a1.941,1.941,0,0,1-.25-0.7q0.05-3.645,0-7.2a0.379,0.379,0,0,1,.1-0.32,0.5,0.5,0,0,1,.3-0.08h1.55a1.474,1.474,0,0,0,1.125-.45,1.8,1.8,0,0,0,.475-1.15v-1.65a1.552,1.552,0,0,0-.45-1.15,1.622,1.622,0,0,0-1.2-.45h-16.05a1.722,1.722,0,0,0-1.25.43,1.652,1.652,0,0,0-.45,1.27v1.6a1.755,1.755,0,0,0,.475,1.1,1.474,1.474,0,0,0,1.125.45,9.973,9.973,0,0,0,1.375,0,0.519,0.519,0,0,1,.475.08,0.781,0.781,0,0,1,.1.47q-0.05,3.345,0,6.65a2.09,2.09,0,0,1-.3,1.1l-11.1,20.7a6.541,6.541,0,0,0-.7,1.7,1.652,1.652,0,0,0,1.45,2.2,5.753,5.753,0,0,0,1.3.1h31.25a3.855,3.855,0,0,0,1.5-.25A1.369,1.369,0,0,0,439.419,1714.15Zm-22.2-40.52a1.953,1.953,0,0,1-.575-1.43,2.015,2.015,0,0,1,.575-1.45,1.948,1.948,0,0,1,1.425-.62,1.833,1.833,0,0,1,1.45.6,2.031,2.031,0,0,1,.6,1.47,2.049,2.049,0,0,1-2.05,2.05A2.115,2.115,0,0,1,417.219,1673.63Zm5.05-3.13a1.616,1.616,0,0,1-.525-1.22,1.8,1.8,0,0,1,1.75-1.78,1.734,1.734,0,0,1,1.225.5,1.65,1.65,0,0,1,.525,1.25,1.709,1.709,0,0,1-1.75,1.75A1.734,1.734,0,0,1,422.269,1670.5Zm4.625,23.45,10.3,18.8a3.751,3.751,0,0,1,.45.88,0.2,0.2,0,0,1-.175.27,6.171,6.171,0,0,1-.975.05h-31.1a1.131,1.131,0,0,1-.725-0.12,1.032,1.032,0,0,1,.225-0.68q0.649-1.245,2.6-4.8l4.85-8.85a0.933,0.933,0,0,1,.325-0.4,0.6,0.6,0,0,1,.525.05,19.047,19.047,0,0,0,3.775.75,4.321,4.321,0,0,0,3.775-1.3c0.3-.3.933-0.98,1.9-2.05a13.925,13.925,0,0,1,3.6-2.8,0.712,0.712,0,0,1,.4-0.07,0.463,0.463,0,0,1,.3.27h-0.05Zm-2.35,15.13a1.943,1.943,0,0,0,.2-1.6,2.054,2.054,0,0,0-1.025-1.25,2.132,2.132,0,0,0-2.875.8,2.1,2.1,0,0,0-.175,1.6,2,2,0,0,0,1,1.3,2.05,2.05,0,0,0,1.625.17A2.189,2.189,0,0,0,424.544,1709.08Zm5.025-4.8a2.386,2.386,0,0,0,.2-1.85,2.476,2.476,0,0,0-1.15-1.5,2.325,2.325,0,0,0-1.85-.28,2.352,2.352,0,0,0-1.5,1.18,2.394,2.394,0,0,0-.25,1.9,2.454,2.454,0,0,0,1.175,1.5,2.3,2.3,0,0,0,1.9.22A2.389,2.389,0,0,0,429.569,1704.28Zm-10.725-18.08a3.5,3.5,0,0,1-1.05-2.57,3.465,3.465,0,0,1,1.075-2.58,3.682,3.682,0,0,1,5.15,0,3.622,3.622,0,0,1,0,5.15A3.713,3.713,0,0,1,418.844,1686.2Zm-0.7,7.53a2.643,2.643,0,0,1,1.825-4.53,2.568,2.568,0,0,1,1.85.75,2.477,2.477,0,0,1,.775,1.85,2.62,2.62,0,0,1-.75,1.88,2.493,2.493,0,0,1-1.85.77A2.435,2.435,0,0,1,418.144,1693.73Z" transform="translate(-375.5 -1649.5)"/>-->
-<!--      </svg>-->
-<!--      </svg>-->
-      <h2 class="c-section-heading__header">Experience</h2>
-    </div>
-
-    <div class="c-screen-education o-screen-education">
-      <div class="o-screen-education__col">
-        <div class="c-timeline">
-          <ul class="c-timeline__list">
-            <li class="c-timeline__item">
-              <header class="c-timeline__header">
-                  <span class="c-timeline__time">2025.7 - Current</span>
-                  <span class="c-timeline__dot"></span>
-                  <h4 class="c-timeline__heading">Graduate School of Information Sciences (GSIS), Tohoku University.</h4>
-                  <p class="c-timeline__body"><i> Part-time researcher (学術研究員)</i> </p>
-              </header>
-              <p class="c-timeline__body"></p>
-          </li>
-            <li class="c-timeline__item">
-              <header class="c-timeline__header">
-                  <span class="c-timeline__time">2024.10 - Current</span>
-                  <span class="c-timeline__dot"></span>
-                  <h4 class="c-timeline__heading">Machine Learning Solutions (MLS) Inc.</h4>
-                  <p class="c-timeline__body"><i> AI architect</i> </p>
-              </header>
-              <p class="c-timeline__body"></p>
-          </li>
-          <li class="c-timeline__item">
-              <header class="c-timeline__header">
-                  <span class="c-timeline__time">2023.11 - 2024.4</span>
-                  <span class="c-timeline__dot"></span>
-                  <h4 class="c-timeline__heading">IEC Lab, North Carolina State University, US</h4>
-                  <p class="c-timeline__body"><i> Visiting Researcher (客員研究員)</i> </p>
-              </header>
-              <p class="c-timeline__body"></p>
-          </li>
-            <li class="c-timeline__item">
-              <header class="c-timeline__header">
-                  <span class="c-timeline__time">2021.4 - Current</span>
-                <span class="c-timeline__dot"></span>
-                <h4 class="c-timeline__heading">RIKEN AIP Natural Language Understanding Team</h4>
-                  <p class="c-timeline__body"><i> Part-time Researcher (リサーチパートタイマー)</i> </p>
-              </header>
-              <p class="c-timeline__body"></p>
-            </li>
-            <li class="c-timeline__item">
-              <header class="c-timeline__header">
-                <span class="c-timeline__time">2021.4 - 2025.3</span>
-                <span class="c-timeline__dot"></span>
-                <h4 class="c-timeline__heading">Graduate Program in Data Science, Tohoku University</h4>
-                  <p class="c-timeline__body"><i> Research Assistant</i> </p>
-              </header>
-              <li class="c-timeline__item">
-                  <header class="c-timeline__header">
-                      <span class="c-timeline__time">2020.9 - 2021.3</span>
-                      <span class="c-timeline__dot"></span>
-                      <h4 class="c-timeline__heading">Inui-Suzuki Lab, Tohoku University</h4>
-                      <p class="c-timeline__body"><i> Teaching Assistant (Innovative Engineering Seminar)</i> </p>
-                  </header>
-              </li>
-            </li>
-              <li class="c-timeline__item">
-                  <header class="c-timeline__header">
-                      <span class="c-timeline__time">2020.4 - 2020.8</span>
-                      <span class="c-timeline__dot"></span>
-                      <h4 class="c-timeline__heading">School of Engineering, Tohoku University</h4>
-                      <p class="c-timeline__body"><i> Teaching Assistant (Programming Practice on C) </i> </p>
-                  </header>
-              </li>
-
-          </ul>
-        </div>
-      </div>
-      <div class="o-screen-education__col o-screen-education__col--narrow">
-<!--         <figure class="c-screen-education__image">
-          <img src="pic/nue8nu3otjo-nasa.jpg" alt="">
-        </figure> -->
-      </div>
-    </div>
-  </div>
-  <!-- EDUCATION -->
-  <div id="section-education" class="o-container js-main-container wow1 fadeIn" data-contentPosition="5">
-    <div class="c-section-heading">
-<!--      <svg class="c-section-heading__icon svg-icon" xmlns="http://www.w3.org/2000/svg" width="91" height="91" viewBox="0 0 91 91">-->
-<!--        <rect class="svg-icon__border" x="0.5" y="0.5" width="90" height="90"/>-->
-<!--        <path class="svg-icon__item" d="M440.894,931.53a1,1,0,0,0,.875-0.325,1.027,1.027,0,0,0,.025-0.925q-0.6-1.749-1-2.8a0.455,0.455,0,0,1-.05-0.35,0.482,0.482,0,0,1,.2-0.25,2.786,2.786,0,0,0,1.075-1.575,2.6,2.6,0,0,0-.175-1.775,2.709,2.709,0,0,0-1.35-1.3,0.48,0.48,0,0,1-.3-0.45V909.43a0.5,0.5,0,0,1,.075-0.3,0.784,0.784,0,0,1,.325-0.2l5.1-1.25a0.922,0.922,0,0,0,.8-0.825,0.789,0.789,0,0,0-.75-0.825l-0.25-.1q-4.85-1.6-10.75-3.25-4.25-1.149-10.85-2.85a8.584,8.584,0,0,0-4.4-.05l-7.75,1.95q2.8-.75-7.25,1.85-4.25,1.1-7.2,1.95a1.447,1.447,0,0,0-.6.275,0.856,0.856,0,0,0,0,1.1,1.957,1.957,0,0,0,.6.325q5.051,1.551,11.45,3.3,3.9,1.05,11.55,3.05a4.679,4.679,0,0,0,2.25-.05l15.55-3.95a0.772,0.772,0,0,1,.4,0,0.474,0.474,0,0,1,.1.4v11.85a0.626,0.626,0,0,1-.3.55,2.7,2.7,0,0,0-1.125,1.35,2.588,2.588,0,0,0-.075,1.7,2.78,2.78,0,0,0,1.05,1.45,0.37,0.37,0,0,1,.225.225,0.766,0.766,0,0,1-.025.325q-0.45,1.2-1.05,2.95a0.987,0.987,0,0,0,.05.825,0.754,0.754,0,0,0,.7.325h2.85Zm-35.5-15.25a2.984,2.984,0,0,0,.85,2.25,8.331,8.331,0,0,0,2.45,1.7,25.045,25.045,0,0,0,6.75,1.75,42.519,42.519,0,0,0,9.15.325,32.329,32.329,0,0,0,8.25-1.525,9.633,9.633,0,0,0,3.7-2.1,3.251,3.251,0,0,0,1.05-2.45v-4.35a0.9,0.9,0,0,0-.1-0.575,1.04,1.04,0,0,0-.6.025l-6.65,1.7q-4,1-6.65,1.7a7.824,7.824,0,0,1-1.35.3,3.532,3.532,0,0,1-1.45,0l-5.35-1.3q-4-.95-9.55-2.55a0.487,0.487,0,0,0-.4-0.025,0.436,0.436,0,0,0-.1.35v4.775Z" transform="translate(-375.5 -865.5)"/>-->
-<!--      </svg>-->
-      <h2 class="c-section-heading__header">Education</h2>
-    </div>
-
-    <div class="c-screen-education o-screen-education">
-      <div class="o-screen-education__col">
-        <div class="c-timeline">
-          <ul class="c-timeline__list">
-            <li class="c-timeline__item">
-              <header class="c-timeline__header">
-                  <span class="c-timeline__time">2022.4 - 2025.3</span>
-                  <!--                <span class="c-timeline__line"></span>-->
-                  <h4 class="c-timeline__heading">Tohoku University</h4>
-              </header>
-              <p class="c-timeline__body">Ph.D. in Information Sciences <br> Advisor: Prof. Kentaro Inui   </p>
-          </li>
-          <li class="c-timeline__item">
-            <header class="c-timeline__header">
-              <span class="c-timeline__time">2020.4 - 2022.3</span>
-<!--                <span class="c-timeline__line"></span>-->
-              <h4 class="c-timeline__heading">Tohoku University</h4>
-            </header>
-            <p class="c-timeline__body"> M.S. in Information Sciences<br>Advisor: Prof. Kentaro Inui   </p>
-          </li>
-            <li class="c-timeline__item">
-              <header class="c-timeline__header">
-                <span class="c-timeline__time">2016.4 - 2020.3</span>
-<!--                <span class="c-timeline__line"></span>-->
-                <h4 class="c-timeline__heading">Tohoku University</h4>
-              </header>
-              <p class="c-timeline__body">B.S. in Engineering <br>Advisor: Prof. Kentaro Inui </p>
-            </li>
-          </ul>
-        </div>
-      </div>
-      <div class="o-screen-education__col o-screen-education__col--narrow">
-        <!--         <figure class="c-screen-education__image">
-                  <img src="pic/nue8nu3otjo-nasa.jpg" alt="">
-                </figure> -->
-      </div>
-    </div>
-      <div id="section-award" class="o-container js-main-container wow1 fadeIn" data-contentPosition="6">
-          <div class="c-section-heading">
-              <!--      <svg class="c-section-heading__icon svg-icon" xmlns="http://www.w3.org/2000/svg" width="91" height="91" viewBox="0 0 91 91">-->
-              <!--        <rect class="svg-icon__border" x="0.5" y="0.5" width="90" height="90"/>-->
-              <!--        <path class="svg-icon__item" d="M440.894,931.53a1,1,0,0,0,.875-0.325,1.027,1.027,0,0,0,.025-0.925q-0.6-1.749-1-2.8a0.455,0.455,0,0,1-.05-0.35,0.482,0.482,0,0,1,.2-0.25,2.786,2.786,0,0,0,1.075-1.575,2.6,2.6,0,0,0-.175-1.775,2.709,2.709,0,0,0-1.35-1.3,0.48,0.48,0,0,1-.3-0.45V909.43a0.5,0.5,0,0,1,.075-0.3,0.784,0.784,0,0,1,.325-0.2l5.1-1.25a0.922,0.922,0,0,0,.8-0.825,0.789,0.789,0,0,0-.75-0.825l-0.25-.1q-4.85-1.6-10.75-3.25-4.25-1.149-10.85-2.85a8.584,8.584,0,0,0-4.4-.05l-7.75,1.95q2.8-.75-7.25,1.85-4.25,1.1-7.2,1.95a1.447,1.447,0,0,0-.6.275,0.856,0.856,0,0,0,0,1.1,1.957,1.957,0,0,0,.6.325q5.051,1.551,11.45,3.3,3.9,1.05,11.55,3.05a4.679,4.679,0,0,0,2.25-.05l15.55-3.95a0.772,0.772,0,0,1,.4,0,0.474,0.474,0,0,1,.1.4v11.85a0.626,0.626,0,0,1-.3.55,2.7,2.7,0,0,0-1.125,1.35,2.588,2.588,0,0,0-.075,1.7,2.78,2.78,0,0,0,1.05,1.45,0.37,0.37,0,0,1,.225.225,0.766,0.766,0,0,1-.025.325q-0.45,1.2-1.05,2.95a0.987,0.987,0,0,0,.05.825,0.754,0.754,0,0,0,.7.325h2.85Zm-35.5-15.25a2.984,2.984,0,0,0,.85,2.25,8.331,8.331,0,0,0,2.45,1.7,25.045,25.045,0,0,0,6.75,1.75,42.519,42.519,0,0,0,9.15.325,32.329,32.329,0,0,0,8.25-1.525,9.633,9.633,0,0,0,3.7-2.1,3.251,3.251,0,0,0,1.05-2.45v-4.35a0.9,0.9,0,0,0-.1-0.575,1.04,1.04,0,0,0-.6.025l-6.65,1.7q-4,1-6.65,1.7a7.824,7.824,0,0,1-1.35.3,3.532,3.532,0,0,1-1.45,0l-5.35-1.3q-4-.95-9.55-2.55a0.487,0.487,0,0,0-.4-0.025,0.436,0.436,0,0,0-.1.35v4.775Z" transform="translate(-375.5 -865.5)"/>-->
-<!--      </svg>-->
-              <h2 class="c-section-heading__header">Award</h2>
-              <ul class="c-tabs__listaward">
-                  <li>
-                      <h4><a href="">ACL-SRW Best paper</a></h4>
-                      <p> 2023.7</p>
-                  </li>
-                  <li>
-                      <h4><a href="https://www.aied2023.org/best_papers.html"> AIED2023 Best Paper Nominee </a></h4>
-                      <p> 2023.7</p>
-                  </li>
-                  <li>
-                      <h4><a href="https://www.anlp.jp/nlp2023/award.html"> ⾔語処理学会第 29 回年次⼤会　委員特別賞 </a></h4>
-                      <p> 2023.3</p>
-                  </li>
-                  <li>
-                      <h4><a href="https://aied2022.webspace.durham.ac.uk/best-paper-nominee-all-student-papers%ef%bf%bc/">AIED2022 Best Paper Nominee</a> </h4>
-                      <p> 2022.7
-                  </li>
-                  <li>
-                      <h4><a href="https://www.anlp.jp/nlp2021/award.html"> ⾔語処理学会第 27 回年次⼤会　委員特別賞 </a></h4>
-                      <p> 2021.3</p>
-                  </li>
-
-              </ul>
+          <span class="timeline__date">2024.10 — Current</span>
+          <div>
+            <div class="timeline__primary">Machine Learning Solutions (MLS) Inc.</div>
+            <div class="timeline__secondary">AI Architect</div>
           </div>
+        </li>
+        <li>
+          <span class="timeline__date">2023.11 — 2024.4</span>
+          <div>
+            <div class="timeline__primary">IEC Lab, North Carolina State University, US</div>
+            <div class="timeline__secondary">Visiting Researcher (客員研究員)</div>
+          </div>
+        </li>
+        <li>
+          <span class="timeline__date">2021.4 — Current</span>
+          <div>
+            <div class="timeline__primary">RIKEN AIP — Natural Language Understanding Team</div>
+            <div class="timeline__secondary">Part-time Researcher (リサーチパートタイマー)</div>
+          </div>
+        </li>
+        <li>
+          <span class="timeline__date">2021.4 — 2025.3</span>
+          <div>
+            <div class="timeline__primary">Graduate Program in Data Science, Tohoku University</div>
+            <div class="timeline__secondary">Research Assistant</div>
+          </div>
+        </li>
+        <li>
+          <span class="timeline__date">2020.9 — 2021.3</span>
+          <div>
+            <div class="timeline__primary">Inui-Suzuki Lab, Tohoku University</div>
+            <div class="timeline__secondary">Teaching Assistant — Innovative Engineering Seminar</div>
+          </div>
+        </li>
+        <li>
+          <span class="timeline__date">2020.4 — 2020.8</span>
+          <div>
+            <div class="timeline__primary">School of Engineering, Tohoku University</div>
+            <div class="timeline__secondary">Teaching Assistant — Programming Practice on C</div>
+          </div>
+        </li>
+      </ul>
+    </div>
+
+    <div id="education">
+      <div class="section-title">
+        <h2 class="section-title__en">Education</h2>
+        <span class="section-title__ja">学歴</span>
+        <span class="section-title__rule"></span>
       </div>
+      <ul class="timeline">
+        <li>
+          <span class="timeline__date">2022.4 — 2025.3</span>
+          <div>
+            <div class="timeline__primary">Tohoku University — Ph.D. in Information Sciences</div>
+            <div class="timeline__secondary">Advisor: Prof. Kentaro Inui</div>
+          </div>
+        </li>
+        <li>
+          <span class="timeline__date">2020.4 — 2022.3</span>
+          <div>
+            <div class="timeline__primary">Tohoku University — M.S. in Information Sciences</div>
+            <div class="timeline__secondary">Advisor: Prof. Kentaro Inui</div>
+          </div>
+        </li>
+        <li>
+          <span class="timeline__date">2016.4 — 2020.3</span>
+          <div>
+            <div class="timeline__primary">Tohoku University — B.S. in Engineering</div>
+            <div class="timeline__secondary">Advisor: Prof. Kentaro Inui</div>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- ============================ AWARDS ============================ -->
+<section class="section section--panel" id="awards">
+  <div class="section-title">
+    <h2 class="section-title__en">Awards</h2>
+    <span class="section-title__ja">受賞</span>
+    <span class="section-title__rule"></span>
   </div>
 
-</main>
+  <ul class="awards-list">
+    <li>
+      <span class="awards-list__year">2023.7</span>
+      <div>
+        <div class="awards-list__title awards-list__title--en">ACL-SRW Best Paper</div>
+        <div class="awards-list__body">Association for Computational Linguistics — Student Research Workshop</div>
+      </div>
+    </li>
+    <li>
+      <span class="awards-list__year">2023.7</span>
+      <div>
+        <div class="awards-list__title awards-list__title--en"><a href="https://www.aied2023.org/best_papers.html">AIED 2023 Best Paper Nominee</a></div>
+        <div class="awards-list__body">24th International Conference on Artificial Intelligence in Education</div>
+      </div>
+    </li>
+    <li>
+      <span class="awards-list__year">2023.3</span>
+      <div>
+        <div class="awards-list__title"><a href="https://www.anlp.jp/nlp2023/award.html">言語処理学会第29回年次大会 委員特別賞</a></div>
+        <div class="awards-list__body">Association for Natural Language Processing, Japan</div>
+      </div>
+    </li>
+    <li>
+      <span class="awards-list__year">2022.7</span>
+      <div>
+        <div class="awards-list__title awards-list__title--en"><a href="https://aied2022.webspace.durham.ac.uk/best-paper-nominee-all-student-papers%ef%bf%bc/">AIED 2022 Best Paper Nominee</a></div>
+        <div class="awards-list__body">23rd International Conference on Artificial Intelligence in Education</div>
+      </div>
+    </li>
+    <li>
+      <span class="awards-list__year">2021.3</span>
+      <div>
+        <div class="awards-list__title"><a href="https://www.anlp.jp/nlp2021/award.html">言語処理学会第27回年次大会 委員特別賞</a></div>
+        <div class="awards-list__body">Association for Natural Language Processing, Japan</div>
+      </div>
+    </li>
+  </ul>
+</section>
 
-      <footer class="c-main-footer js-main-footer">
-  <div class="c-main-footer__bottom js-main-footer-bottom">
-    <p class="c-main-footer__text"></p>
-  </div>
+<!-- ============================ FOOTER ============================ -->
+<footer class="footer-mini">
+  <div class="footer-mini__copy">© 2026 Hiroaki Funayama · 舟山 弘晃</div>
+  <div class="footer-mini__updated">Last updated April 2026</div>
 </footer>
 
-    </div>
+<script>
+  (function () {
+    var toggle = document.querySelector('.top-nav__menu-toggle');
+    var list = document.getElementById('site-nav');
+    if (toggle && list) {
+      toggle.addEventListener('click', function () {
+        list.classList.toggle('is-open');
+      });
+      list.addEventListener('click', function (e) {
+        if (e.target.tagName === 'A') list.classList.remove('is-open');
+      });
+    }
+  })();
 
-    <script src="components/jquery.min.js"></script>
-    <script src="components/wow.min.js"></script>
-    <script src="js/jquery.waypoints.min.js"></script>
-    <script src="js/inview.min.js"></script>
-    <script src="js/main.js"></script>
+  (function () {
+    var tabs = document.querySelectorAll('.pub-filter__tab');
+    var pubList = document.getElementById('pub-list');
+    var countEl = document.getElementById('pub-count');
+    if (!tabs.length || !pubList || !countEl) return;
 
+    var items = pubList.querySelectorAll('li[data-type]');
+
+    function apply(filter) {
+      var visible = 0;
+      items.forEach(function (li) {
+        var match = filter === 'all' || li.dataset.type === filter;
+        li.style.display = match ? '' : 'none';
+        if (match) visible += 1;
+      });
+      countEl.textContent = visible + ' ' + (visible === 1 ? 'entry' : 'entries');
+    }
+
+    tabs.forEach(function (tab) {
+      tab.addEventListener('click', function () {
+        tabs.forEach(function (t) {
+          t.classList.remove('is-active');
+          t.setAttribute('aria-selected', 'false');
+        });
+        tab.classList.add('is-active');
+        tab.setAttribute('aria-selected', 'true');
+        apply(tab.dataset.filter);
+      });
+    });
+
+    apply('all');
+  })();
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary

ui_planのデザイン案 (Aesthetic: mono / Accent: default / Density: compact / Hero size: modest) に沿ってプロフィールサイトを全面再デザイン。

- 新規CSS `css/main-mono.css` で EB Garamond + Noto Serif JP + JetBrains Mono のエディトリアル調タイポグラフィ
- Heroセクションを刷新 (氏名 + 写真 + メタ情報) し、Affiliation / Interests / Contact を縦並びリストで統一
- Publicationsにフィルタタブ (All / Journal / International / Domestic) を実装
- 本文サイズを段階的に底上げし可読性を改善
- レスポンシブ対応 (デスクトップ / モバイル) を整備
- Contactのラベル整列とラベル名修正 (Tohoku → Tohoku Univ.)

## Test plan

- [ ] デスクトップ (1280px) でHero / Publications / Talks / Experience / Education / Awards の表示確認
- [ ] モバイル (375px) でハンバーガーメニュー、Heroの写真サイズ、Publicationsフィルタタブの表示確認
- [ ] Publicationsフィルタタブ (All / Journal / International / Domestic) の切替動作とカウント表示
- [ ] 各論文・受賞・講演のリンク動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)