### PR TITLE
所属と経歴を更新

### DIFF
--- a/css/main-mono.css
+++ b/css/main-mono.css
@@ -359,11 +359,39 @@ img {
   margin-bottom: 4px;
 }
 
+.affil-list--affiliations {
+  display: grid;
+  gap: 7px;
+}
+
+.affil-list--affiliations li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  column-gap: 24px;
+  align-items: baseline;
+  margin-bottom: 0;
+  line-height: 1.35;
+}
+
+.affil-list__org {
+  min-width: 0;
+}
+
 .affil-list li small {
   font-family: var(--jp);
   color: var(--muted);
   font-size: 15px;
   margin-left: 4px;
+}
+
+.affil-list__role {
+  justify-self: end;
+  font-family: var(--jp);
+  font-size: 14px;
+  line-height: 1.45;
+  color: var(--muted);
+  text-align: right;
+  white-space: nowrap;
 }
 
 .tag-list {
@@ -971,6 +999,14 @@ img {
   .hero__meta dd {
     padding-top: 4px;
     border-top: none;
+  }
+
+  .affil-list--affiliations li {
+    column-gap: 12px;
+  }
+
+  .affil-list__role {
+    font-size: 13px;
   }
 
   .news-list li {

--- a/index.html
+++ b/index.html
@@ -58,10 +58,23 @@
       <dl class="hero__meta">
         <dt>Affiliation<small>所属</small></dt>
         <dd>
-          <ul class="affil-list">
-            <li><a href="https://machine-learning.co.jp/">Machine Learning Solutions (MLS) Inc.</a></li>
-            <li><a href="https://www.nlp.ecei.tohoku.ac.jp/">Tohoku NLP Group</a> <small>東北大学 自然言語処理研究グループ</small></li>
-            <li><a href="https://www.riken.jp/research/labs/aip/goalorient_tech/nat_lang_understand/index.html">RIKEN AIP</a> <small>理研AIP 自然言語理解チーム</small></li>
+          <ul class="affil-list affil-list--affiliations">
+            <li>
+              <span class="affil-list__org"><a href="https://machine-learning.co.jp/">Machine Learning Solutions (MLS) Inc.</a></span>
+              <span class="affil-list__role">AIアーキテクト</span>
+            </li>
+            <li>
+              <span class="affil-list__org"><a href="https://osaka-kyoiku.ac.jp/">Osaka Kyoiku University</a> <small>大阪教育大学</small></span>
+              <span class="affil-list__role">特任助教</span>
+            </li>
+            <li>
+              <span class="affil-list__org"><a href="https://www.nlp.ecei.tohoku.ac.jp/">Tohoku NLP Group</a> <small>東北大学 自然言語処理研究グループ</small></span>
+              <span class="affil-list__role">学術研究員</span>
+            </li>
+            <li>
+              <span class="affil-list__org"><a href="https://www.riken.jp/research/labs/aip/goalorient_tech/nat_lang_understand/index.html">RIKEN AIP</a> <small>理研AIP 自然言語理解チーム</small></span>
+              <span class="affil-list__role">パートタイムリサーチャー</span>
+            </li>
           </ul>
         </dd>
 
@@ -70,8 +83,6 @@
           <ul class="affil-list">
             <li>Natural Language Processing <small>自然言語処理</small></li>
             <li>AI for Education <small>教育AI</small></li>
-            <li>Learning Support Systems <small>学習支援システム</small></li>
-            <li>Large Language Models <small>大規模言語モデル</small></li>
           </ul>
         </dd>
 
@@ -533,17 +544,31 @@
       </div>
       <ul class="timeline">
         <li>
-          <span class="timeline__date">2025.7 — Current</span>
+          <span class="timeline__date">2024.10 — Present</span>
+          <div>
+            <div class="timeline__primary">Machine Learning Solutions (MLS) Inc.</div>
+            <div class="timeline__secondary">AI Architect</div>
+          </div>
+        </li>
+        <li>
+          <span class="timeline__date">2026.7 — Present</span>
+          <div>
+            <div class="timeline__primary">Osaka Kyoiku University</div>
+            <div class="timeline__secondary">Specially Appointed Assistant Professor (特任助教)</div>
+          </div>
+        </li>
+        <li>
+          <span class="timeline__date">2025.7 — Present</span>
           <div>
             <div class="timeline__primary">Graduate School of Information Sciences (GSIS), Tohoku University</div>
             <div class="timeline__secondary">Part-time Researcher (学術研究員)</div>
           </div>
         </li>
         <li>
-          <span class="timeline__date">2024.10 — Current</span>
+          <span class="timeline__date">2021.4 — Present</span>
           <div>
-            <div class="timeline__primary">Machine Learning Solutions (MLS) Inc.</div>
-            <div class="timeline__secondary">AI Architect</div>
+            <div class="timeline__primary">RIKEN AIP — Natural Language Understanding Team</div>
+            <div class="timeline__secondary">Part-time Researcher (リサーチパートタイマー)</div>
           </div>
         </li>
         <li>
@@ -551,13 +576,6 @@
           <div>
             <div class="timeline__primary">IEC Lab, North Carolina State University, US</div>
             <div class="timeline__secondary">Visiting Researcher (客員研究員)</div>
-          </div>
-        </li>
-        <li>
-          <span class="timeline__date">2021.4 — Current</span>
-          <div>
-            <div class="timeline__primary">RIKEN AIP — Natural Language Understanding Team</div>
-            <div class="timeline__secondary">Part-time Researcher (リサーチパートタイマー)</div>
           </div>
         </li>
         <li>
@@ -667,7 +685,7 @@
 <!-- ============================ FOOTER ============================ -->
 <footer class="footer-mini">
   <div class="footer-mini__copy">© 2026 Hiroaki Funayama · 舟山 弘晃</div>
-  <div class="footer-mini__updated">Last updated April 2026</div>
+  <div class="footer-mini__updated">Last updated July 2026</div>
 </footer>
 
 <script>


### PR DESCRIPTION
## 概要
所属、専門、経歴、最終更新日の表示を更新しました。

## 背景
現在の所属と肩書をプロフィール上で分かりやすく見せるため、所属欄と経歴欄の情報を整理しました。

## 変更内容
- 所属欄に肩書を追加し、大阪教育大学を2番目に追加
- 所属欄の表示を2列構成にして、縦に長くなりすぎないよう調整
- 専門欄を「Natural Language Processing」「AI for Education」の2項目に整理
- 経歴欄に大阪教育大学 特任助教を追加
- 現職の期間表記を `Current` から `Present` に統一
- 現職の経歴を主たる所属順に並べ替え
- フッターの最終更新日を July 2026 に更新

## テスト・検証
- `git diff --check -- index.html css/main-mono.css`
- ステージ済み差分が `index.html` と `css/main-mono.css` のみであることを確認